### PR TITLE
Add support for batch format of CloudEvents

### DIFF
--- a/Service Connector  Hub/README.md
+++ b/Service Connector  Hub/README.md
@@ -1,0 +1,9 @@
+# Service Connector Hub function
+OCI function used for log forwarding. See [DataDog documentation for more info](https://docs.datadoghq.com/integrations/oracle_cloud_infrastructure/?tab=serviceconnectorhub#oci-function).
+
+
+## Tests
+
+To run tests, cd into the current directory and run:
+
+`python3 -m unittest`

--- a/Service Connector  Hub/func.yaml
+++ b/Service Connector  Hub/func.yaml
@@ -2,7 +2,8 @@ schema_version: 20180708
 name: datadogapp
 version: 0.0.1
 runtime: python
-entrypoint: /python/bin/fdk /function/func.py handler memory: 1024
+entrypoint: /python/bin/fdk /function/func.py handler
+memory: 1024
 timeout: 120
 config:
   DATADOG_HOST: https://http-intake.logs.datadoghq.com/v1/input 

--- a/Service Connector  Hub/tests/test_func.py
+++ b/Service Connector  Hub/tests/test_func.py
@@ -1,0 +1,89 @@
+import os
+from io import BytesIO
+from func import handler
+from unittest import TestCase, mock
+
+def to_BytesIO(str):
+    """ Helper function to turn string test data into expected BytesIO asci encoded bytes """
+    return BytesIO(bytes(str, 'ascii'))
+
+class TestLogForwarderFunction(TestCase):
+    """ Test simple and batch format json CloudEvent payloads """
+
+    def setUp(self):
+        # Set env variables expected by function
+        os.environ['DATADOG_HOST'] = "http://datadog.woof"
+        os.environ['DATADOG_TOKEN'] = "VERY-SECRET-TOKEN-2000"
+        return super().setUp()
+
+    @mock.patch("requests.post")
+    def testSimpleData(self, mock_post, ):
+        """ Test single CloudEvent payload """
+
+        payload = """
+        {
+            "specversion" : "1.0",
+            "type" : "com.example.someevent",
+            "source" : "/mycontext",
+            "id" : "C234-1234-1234",
+            "time" : "2018-04-05T17:31:00Z",
+            "comexampleextension1" : "value",
+            "comexampleothervalue" : 5,
+            "datacontenttype" : "application/json",
+            "data" : {
+                "appinfoA" : "abc",
+                "appinfoB" : 123,
+                "appinfoC" : true
+            }
+        }
+        """
+        handler(ctx=None, data=to_BytesIO(payload))
+        mock_post.assert_called_once()
+        self.assertEqual(mock_post.mock_calls[0].kwargs['data'],
+                        '{"source": "/mycontext", "time": "2018-04-05T17:31:00Z", "data": '
+                        '{"appinfoA": "abc", "appinfoB": 123, "appinfoC": true}, "ddsource": '
+                        '"oracle_cloud", "service": "OCI Logs"}'
+                        )
+
+    @mock.patch("requests.post")
+    def testBatchFormat(self, mock_post):
+        """ Test batch format case, where we get an array of 'CloudEvents' """
+        batch = """
+        [
+            {
+                "specversion" : "1.0",
+                "type" : "com.example.someevent",
+                "source" : "/mycontext/4",
+                "id" : "B234-1234-1234",
+                "time" : "2018-04-05T17:31:00Z",
+                "comexampleextension1" : "value",
+                "comexampleothervalue" : 5,
+                "datacontenttype" : "application/vnd.apache.thrift.binary",
+                "data_base64" : "... base64 encoded string ..."
+            },
+            {
+                "specversion" : "1.0",
+                "type" : "com.example.someotherevent",
+                "source" : "/mycontext/9",
+                "id" : "C234-1234-1234",
+                "time" : "2018-04-05T17:31:05Z",
+                "comexampleextension1" : "value",
+                "comexampleothervalue" : 5,
+                "datacontenttype" : "application/json",
+                "data" : {
+                    "appinfoA" : "potatoes",
+                    "appinfoB" : 123,
+                    "appinfoC" : true
+                }
+            }
+        ]
+        """
+        handler(ctx=None, data=to_BytesIO(batch))
+        self.assertEqual(mock_post.call_count, 2, "Data was not successfully submitted for entire batch")
+        self.assertEqual(
+                        [arg.kwargs['data'] for arg in mock_post.call_args_list],
+                        ['{"source": "/mycontext/4", "time": "2018-04-05T17:31:00Z", "data": {}, '
+                                '"ddsource": "oracle_cloud", "service": "OCI Logs"}',
+                            '{"source": "/mycontext/9", "time": "2018-04-05T17:31:05Z", "data": '
+                                '{"appinfoA": "potatoes", "appinfoB": 123, "appinfoC": true}, "ddsource": '
+                                '"oracle_cloud", "service": "OCI Logs"}'])


### PR DESCRIPTION
What does this PR do?
---------------------
Add support for batch CloudEvents which is a list.
Corrects memory setting in yaml.

Who will it impact?
-------------------
New users of OCI function to forward logs.

Motivation
----------
Issue reported via CLOUDS-1802

Testing Guidelines
------------------
Built the application on Oracle Cloud Shell.
Reproduced both errors and fixed through unit tests.

Release Checklist
-----------------

- [x] This code has automated tests
- [ ] Changes are being deployed behind a feature flag, if applicable
- [ ] Related changes to databases, devops, and/or consul-config have been made, if applicable
- [ ] These changes will work with production-level load
- [ ] I have a plan to verify that these changes are working as expected after deploy
- [ ] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected
- [x] If PR impacts documentation, docs team has been notified or [a card has been created on the documentation triage](https://datadoghq.atlassian.net/jira/software/projects/DOCS/boards/199)
- [ ] If PR changes route(s), I have followed the process to [update the routes in dogweb and k8s-resources](https://datadoghq.atlassian.net/wiki/spaces/API/pages/1563885968/Adding+A+New+Route+to+McNulty).
- [ ] If the PR adds route(s), I have followed the [API Production Readiness Review](https://dtdg.co/api-prr)

See Also: https://github.com/DataDog/devops/wiki/Code-Workflow#deploying-to-production

Security Checklist
-------------------

This PR creates, modifies, or deletes:

- [ ] API Routes: API routes, parameters and/or user permissions
- [ ] Authentication: Authentication mechanism (SAML, OAuth, password etc.)
- [ ] Credentials: Server side credentials or secrets in configuration/source code
- [ ] Cryptography: Cryptographic directives (encryption, hashing, certificates, signatures, random numbers, etc.)
- [ ] User Data: User input/sensitive content in URL params, logs, error messages, etc.
- [x] **None of the above** 

Unsure? Have a question? Request a review from `@DataDog/osa`!

Additional Notes
----------------
