### PR TITLE
ECI-413 [OCI] Add resiliency to metric stack

### DIFF
--- a/datadog-oci-orm/metrics-setup/function_setup.tf
+++ b/datadog-oci-orm/metrics-setup/function_setup.tf
@@ -1,10 +1,36 @@
 resource "null_resource" "Login2OCIR" {
-  provisioner "local-exec" {
-    command = "echo '${var.oci_docker_password}' |  docker login ${local.oci_docker_repository} --username ${local.ocir_namespace}/${var.oci_docker_username} --password-stdin"
-  }
+   provisioner "local-exec" {
+       command = <<EOT
+           #!/bin/bash
+           set -e
+
+           for i in {1..5}; do
+               echo "${var.oci_docker_password}" | docker login ${local.oci_docker_repository} --username ${local.ocir_namespace}/${var.oci_docker_username} --password-stdin && break
+               echo "Retrying Docker login... attempt $i"
+               sleep 10
+           done
+
+           # Check if login was successful
+           if [ $i -eq 5 ]; then
+               echo "Error: Docker login failed after 5 attempts. Trying to login through Oracle Identity Cloud Service"
+               for j in {1..5}; do
+                   echo "${var.oci_docker_password}" | docker login ${local.oci_docker_repository} --username ${local.ocir_namespace}/oracleidentitycloudservice/$username --password-stdin && break
+                   echo "Retrying Docker login through Identity service... attempt $j"
+                   sleep 5
+               done
+               if [ $j -eq 5 ]; then
+                   echo "Error: Docker login failed after 5 attempts."
+                   exit 1
+               fi
+           fi
+       EOT
+   }
+   triggers = {
+       always_run = "${timestamp()}"
+   }
 }
 
-### Repository in the Container Image Registry for the container images underpinning the function 
+### Repository in the Container Image Registry for the container images underpinning the function
 resource "oci_artifacts_container_repository" "function_repo" {
   # note: repository = store for all images versions of a specific container image - so it included the function name
   depends_on     = [null_resource.Login2OCIR]
@@ -18,10 +44,6 @@ resource "oci_artifacts_container_repository" "function_repo" {
 # ### build the function into a container image and push that image to the repository in the OCI Container Image Registry
 resource "null_resource" "FnImagePushToOCIR" {
   depends_on = [oci_artifacts_container_repository.function_repo, oci_functions_application.metrics_function_app, null_resource.Login2OCIR]
-
-  provisioner "local-exec" {
-    command = "echo '${var.oci_docker_password}' |  docker login ${local.oci_docker_repository} --username ${local.ocir_namespace}/${var.oci_docker_username} --password-stdin"
-  }
 
   # remove function image (if it exists) from local container registry
   provisioner "local-exec" {
@@ -47,4 +69,11 @@ resource "null_resource" "FnImagePushToOCIR" {
     working_dir = "metrics-function"
   }
 
+}
+
+resource "null_resource" "wait_for_image" {
+  depends_on = [null_resource.FnImagePushToOCIR]
+  provisioner "local-exec" {
+    command = "sleep 60"
+  }
 }

--- a/datadog-oci-orm/metrics-setup/functions.tf
+++ b/datadog-oci-orm/metrics-setup/functions.tf
@@ -21,7 +21,7 @@ resource "oci_functions_application" "metrics_function_app" {
 }
 
 resource "oci_functions_function" "metrics_function" {
-  depends_on = [null_resource.FnImagePushToOCIR, oci_functions_application.metrics_function_app]
+  depends_on = [oci_functions_application.metrics_function_app, null_resource.wait_for_image]
   #Required
   application_id = oci_functions_application.metrics_function_app.id
   display_name   = "${oci_functions_application.metrics_function_app.display_name}-metrics-function"


### PR DESCRIPTION
**what:**
Add retry mechanism for docker login

Attempt docker login through identity service, in case of failure to login.

Add a delay in pushing function image to container registry and creation of function resource

**why:**
Adding resiliency in metric stack for docker failures

**testing:**
Ran metric stack successfully