### PR TITLE
[ECI-1615] ORM stack: events-forwarder function and cloudEvents IAM

### DIFF
--- a/datadog-integration/main.tf
+++ b/datadog-integration/main.tf
@@ -232,6 +232,7 @@ module "auth" {
   dg_sch_name       = local.dg_sch_name
   dg_fn_name        = local.dg_fn_name
   dg_policy_name    = local.dg_policy_name
+  events_enabled    = var.events_enabled
   defined_tags      = local.defined_tags
 }
 
@@ -264,6 +265,7 @@ module "integration" {
   subscribed_regions              = tolist(local.final_regions_for_stacks)
   datadog_resource_compartment_id = module.compartment.id
   logs_enabled                    = var.logs_enabled
+  events_enabled                  = var.events_enabled
   defined_tags                    = local.defined_tags
 }
 

--- a/datadog-integration/modules/auth/main.tf
+++ b/datadog-integration/modules/auth/main.tf
@@ -230,3 +230,19 @@ resource "oci_identity_policy" "dynamic_group" {
   freeform_tags = var.tags
   defined_tags  = var.defined_tags
 }
+
+resource "oci_identity_policy" "events" {
+  count          = var.events_enabled ? 1 : 0
+  depends_on     = [null_resource.user_group_variable_validation, oci_identity_domains_group.dd_auth]
+  compartment_id = var.tenancy_id
+  description    = "[DO NOT REMOVE] Policy granting the OCI Events service permission to publish to the Datadog events stream and Datadog to manage event rules"
+  name           = "dd-events-cloudevents-policy"
+  statements = [
+    "Allow service cloudEvents to use streams in compartment id ${var.compartment_id}",
+    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage cloudevents-rules in tenancy",
+    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage stream-family in compartment id ${var.compartment_id}",
+    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage serviceconnectors in compartment id ${var.compartment_id}"
+  ]
+  freeform_tags = var.tags
+  defined_tags  = var.defined_tags
+}

--- a/datadog-integration/modules/auth/variables.tf
+++ b/datadog-integration/modules/auth/variables.tf
@@ -80,3 +80,9 @@ variable "dg_policy_name" {
   type        = string
 }
 
+variable "events_enabled" {
+  type        = bool
+  description = "When true, provisions the cloudEvents IAM policy that lets the OCI Events service write to streams in the Datadog compartment."
+  default     = false
+}
+

--- a/datadog-integration/modules/integration/locals.tf
+++ b/datadog-integration/modules/integration/locals.tf
@@ -20,6 +20,9 @@ locals {
         logs_config : {
           Enabled : var.logs_enabled
         }
+        events_config : {
+          Enabled : var.events_enabled
+        }
         defined_tags : [for k, v in var.defined_tags : "${k}:${v}"]
       }
     }

--- a/datadog-integration/modules/integration/variables.tf
+++ b/datadog-integration/modules/integration/variables.tf
@@ -55,6 +55,12 @@ variable "logs_enabled" {
   default     = false
 }
 
+variable "events_enabled" {
+  type        = bool
+  description = "Indicates if OCI events should be enabled/disabled"
+  default     = false
+}
+
 variable "defined_tags" {
   type        = map(string)
   description = "OCI defined tags applied to resources (namespace.key -> value). Sent to Datadog for integration config."

--- a/datadog-integration/modules/regional-stacks/data.tf
+++ b/datadog-integration/modules/regional-stacks/data.tf
@@ -6,11 +6,18 @@ data "http" "token_metrics" {
   url = local.token_metrics
 }
 
+data "http" "token_events" {
+  count = var.events_enabled ? 1 : 0
+  url   = local.token_events
+}
+
 locals {
   logs_token        = jsondecode(data.http.token_logs.response_body).token
   metrics_token     = jsondecode(data.http.token_metrics.response_body).token
+  events_token      = var.events_enabled ? jsondecode(data.http.token_events[0].response_body).token : ""
   image_sha_logs    = contains(keys(data.http.logs_image.response_headers), "Docker-Content-Digest") ? data.http.logs_image.response_headers["Docker-Content-Digest"] : (contains(keys(data.http.logs_image.response_headers), "docker-content-digest") ? data.http.logs_image.response_headers["docker-content-digest"] : "")
   image_sha_metrics = contains(keys(data.http.metrics_image.response_headers), "Docker-Content-Digest") ? data.http.metrics_image.response_headers["Docker-Content-Digest"] : (contains(keys(data.http.metrics_image.response_headers), "docker-content-digest") ? data.http.metrics_image.response_headers["docker-content-digest"] : "")
+  image_sha_events  = var.events_enabled ? (contains(keys(data.http.events_image[0].response_headers), "Docker-Content-Digest") ? data.http.events_image[0].response_headers["Docker-Content-Digest"] : (contains(keys(data.http.events_image[0].response_headers), "docker-content-digest") ? data.http.events_image[0].response_headers["docker-content-digest"] : "")) : ""
 }
 
 
@@ -27,6 +34,15 @@ data "http" "metrics_image" {
   request_headers = {
     Accept        = "application/vnd.oci.image.index.v1+json"
     Authorization = "Bearer ${local.metrics_token}"
+  }
+}
+
+data "http" "events_image" {
+  count = var.events_enabled ? 1 : 0
+  url   = local.image_url_events
+  request_headers = {
+    Accept        = "application/vnd.oci.image.index.v1+json"
+    Authorization = "Bearer ${local.events_token}"
   }
 }
 

--- a/datadog-integration/modules/regional-stacks/locals.tf
+++ b/datadog-integration/modules/regional-stacks/locals.tf
@@ -3,12 +3,15 @@ locals {
   registry_host      = lower("${var.region_key}.ocir.io/iddfxd5j9l2o")
   metrics_image_path = "${local.registry_host}/oci-datadog-forwarder/metrics:latest"
   logs_image_path    = "${local.registry_host}/oci-datadog-forwarder/logs:latest"
+  events_image_path  = "${local.registry_host}/oci-datadog-forwarder/events:latest"
   token_base_path    = "https://${var.region_key}.ocir.io/20180419/docker/token?service=${var.region_key}.ocir.io&scope=repository:iddfxd5j9l2o/oci-datadog-forwarder"
   token_logs         = "${local.token_base_path}/logs:pull"
   token_metrics      = "${local.token_base_path}/metrics:pull"
+  token_events       = "${local.token_base_path}/events:pull"
   image_base_path    = "https://${var.region_key}.ocir.io/v2/iddfxd5j9l2o/oci-datadog-forwarder"
   image_url_logs     = "${local.image_base_path}/logs/manifests/latest"
   image_url_metrics  = "${local.image_base_path}/metrics/manifests/latest"
+  image_url_events   = "${local.image_base_path}/events/manifests/latest"
 
   config = {
     "DD_SITE"                  = var.datadog_site,

--- a/datadog-integration/modules/regional-stacks/main.tf
+++ b/datadog-integration/modules/regional-stacks/main.tf
@@ -33,6 +33,17 @@ resource "oci_functions_function" "metrics_function" {
   image_digest   = length(local.image_sha_metrics) > 0 ? local.image_sha_metrics : null
 }
 
+resource "oci_functions_function" "events_function" {
+  count          = var.events_enabled ? 1 : 0
+  application_id = oci_functions_application.dd_function_app.id
+  display_name   = "dd-events-forwarder"
+  memory_in_mbs  = "256"
+  freeform_tags  = var.tags
+  defined_tags   = local.defined_tags_map
+  image          = local.events_image_path
+  image_digest   = length(local.image_sha_events) > 0 ? local.image_sha_events : null
+}
+
 module "vcn" {
   count                    = var.subnet_ocid == "" ? 1 : 0
   source                   = "oracle-terraform-modules/vcn/oci"

--- a/datadog-integration/modules/regional-stacks/variables.tf
+++ b/datadog-integration/modules/regional-stacks/variables.tf
@@ -51,9 +51,15 @@ variable "subnet_ocid" {
   type        = string
   description = "Optional OCID of an existing subnet to use. If not provided, a new subnet will be created."
   default     = ""
-  
+
   validation {
     condition = var.subnet_ocid == "" || can(regex("^ocid1\\.subnet\\.oc[0-9]\\.", var.subnet_ocid))
     error_message = "If provided, subnet_ocid must be a valid subnet OCID starting with: ocid1.subnet.oc[0-9]."
   }
+}
+
+variable "events_enabled" {
+  type        = bool
+  description = "Indicates if the events-forwarder function should be deployed in this region."
+  default     = false
 }

--- a/datadog-integration/regional_stack.tf
+++ b/datadog-integration/regional_stack.tf
@@ -65,7 +65,7 @@ resource "null_resource" "regional_stacks_create_apply" {
       --config-source ${path.module}/modules/regional-stacks/dd_regional_stack.zip  --variables '{"tenancy_ocid": "${var.tenancy_ocid}", "region": "${each.key}", \
       "compartment_ocid": "${module.compartment.id}", "datadog_site": "${var.datadog_site}", "api_key_secret_id": "${module.kms[0].api_key_secret_id}", \
       "home_region": "${local.home_region_name}", "region_key": "${local.subscribed_regions_map[each.key].region_key}", \
-      "subnet_ocid": "${lookup(local.region_to_subnet_ocid_map, each.key, "")}", "defined_tags": ${jsonencode(jsonencode(local.defined_tags))}}' \
+      "subnet_ocid": "${lookup(local.region_to_subnet_ocid_map, each.key, "")}", "events_enabled": "${var.events_enabled}", "defined_tags": ${jsonencode(jsonencode(local.defined_tags))}}' \
       ${local.stack_create_defined_tags_flag} \
       --wait-for-state ACTIVE \
       --max-wait-seconds 120 \

--- a/datadog-integration/schema.yaml
+++ b/datadog-integration/schema.yaml
@@ -19,6 +19,7 @@ variableGroups:
       - ${datadog_api_key}
       - ${datadog_site}
       - ${logs_enabled}
+      - ${events_enabled}
   - title: "(Optional) Choose specific subnet(s)"
     variables:
       - ${choose_subnet}
@@ -113,6 +114,14 @@ variables:
     type: string
     description: |
       Indicates if logs should be enabled/disabled
+    required: false
+    default: false
+
+  events_enabled:
+    title: Events Enabled
+    type: string
+    description: |
+      Indicates if OCI cloud-event forwarding should be enabled. When true, an additional events-forwarder function and the cloudEvents IAM policy are deployed in each region.
     required: false
     default: false
 

--- a/datadog-integration/variables.tf
+++ b/datadog-integration/variables.tf
@@ -77,6 +77,12 @@ variable "logs_enabled" {
   default     = false
 }
 
+variable "events_enabled" {
+  type        = bool
+  description = "Indicates if OCI cloud-event forwarding should be enabled. When true, the events-forwarder function and the cloudEvents IAM policy are provisioned and the integration is opted in to event management."
+  default     = false
+}
+
 variable "domain_id" {
   type        = string
   description = "The OCID of the Identity Domain to use for the Datadog QuickStart stack"


### PR DESCRIPTION
## What

Threads `var.events_enabled` (bool, default `false`) through the `datadog-integration` Terraform stack so customers can opt in to OCI cloud-event forwarding by re-running the ORM stack.

When `events_enabled = true`:
- **Regional stack** (per region): a new `oci_functions_function "events_function"` (`dd-events-forwarder`, 256 MB) is provisioned next to the existing logs/metrics functions. Image is pulled from `${region}.ocir.io/iddfxd5j9l2o/oci-datadog-forwarder/events:latest` with the same image-digest fetch pattern used for logs/metrics.
- **Auth module** (home region): a new `oci_identity_policy "events"` is created with statements:
  - `Allow service cloudEvents to use streams in compartment id ${dd_compartment}` — lets the OCI Events service write to the stream HubManager will create
  - `Allow group id <dd_auth_group> to manage cloudevents-rules in tenancy` — lets the Datadog auth group create/destroy the per-region events rule
  - `Allow group id <dd_auth_group> to manage stream-family in compartment id ${dd_compartment}` — stream lifecycle
  - `Allow group id <dd_auth_group> to manage serviceconnectors in compartment id ${dd_compartment}` — SCH lifecycle
- **Integration module**: adds `events_config: { Enabled: true }` to the JSON sent to the Datadog API so the integration's opt-in state is recorded.
- **schema.yaml**: adds an `events_enabled` toggle next to `logs_enabled` in the OCI Resource Manager UI.

## Why

Milestone 1 of the OCI events RFC ([ECI-1558](https://datadoghq.atlassian.net/browse/ECI-1558)). The customer-side preconditions for HubManager ([ECI-1616](https://datadoghq.atlassian.net/browse/ECI-1616)) to dynamically create the per-region stream + SCH + events rule:

1. The events-forwarder function must exist as a stable target before HubManager wires up the SCH (per RFC: "If the customer didn't re-apply the stack and opt-in to event management, do not create the rule + stream + SCH, retry on next run").
2. The cloudEvents service principal needs explicit permission to publish to the customer's stream — that's an IAM policy on the customer side.

Default `false` preserves backwards compatibility: customers who don't opt in see zero behavior change to the existing logs/metrics pipeline.

## Stacking note

This PR is **based on `yu.hu/eci-1621-events-forwarder`** (PR #111) so the events function has Go code to image. It does not strictly depend on the Dockerfile PR (#112) at terraform-validate time (the image lookup is an `http` data source, not a build step), but a real apply needs an image at `oci-datadog-forwarder/events:latest`. Once #111 + #112 merge, retarget base to \`master\`.

## Test plan

- [ ] `terraform fmt -check -recursive datadog-integration/` (no terraform locally — run in CI)
- [ ] `terraform validate` against \`datadog-integration/\` and \`datadog-integration/modules/regional-stacks/\`
- [ ] Apply with \`events_enabled=false\` against a test tenancy → verify no events function or events policy is created and existing logs/metrics path unchanged
- [ ] Apply with \`events_enabled=true\` against a test tenancy → verify \`dd-events-forwarder\` exists per region and \`dd-events-cloudevents-policy\` exists at tenancy

## Out of scope

- HubManager lifecycle for stream/rule/SCH → [ECI-1616](https://datadoghq.atlassian.net/browse/ECI-1616)
- cloudchange-worker OCI processor → [ECI-1617](https://datadoghq.atlassian.net/browse/ECI-1617)
- UI opt-in + onboarding docs → [ECI-1619](https://datadoghq.atlassian.net/browse/ECI-1619)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ECI-1558]: https://datadoghq.atlassian.net/browse/ECI-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ