### PR TITLE
fix: drop lockdown_default_seclist to eliminate security-list race

### DIFF
--- a/datadog-integration/modules/regional-stacks/main.tf
+++ b/datadog-integration/modules/regional-stacks/main.tf
@@ -43,7 +43,7 @@ module "vcn" {
   vcn_cidrs                = ["10.0.0.0/16"]
   vcn_dns_label            = "ddvcnmodule"
   vcn_name                 = local.vcn_name
-  lockdown_default_seclist  = true
+  lockdown_default_seclist  = false
   subnets                  = {}
 
   create_nat_gateway           = true

--- a/datadog-terraform-onboarding/modules/regional-stacks/main.tf
+++ b/datadog-terraform-onboarding/modules/regional-stacks/main.tf
@@ -45,7 +45,7 @@ module "vcn" {
   vcn_cidrs                = ["10.0.0.0/16"]
   vcn_dns_label            = "ddvcnmodule"
   vcn_name                 = local.vcn_name
-  lockdown_default_seclist  = true
+  lockdown_default_seclist  = false
   subnets                  = {}
 
   create_nat_gateway           = true


### PR DESCRIPTION
## What

Set `lockdown_default_seclist = false` in `module.vcn` in both `datadog-terraform-onboarding` and `datadog-integration` regional-stacks modules.

## Why

Two Terraform resources were both managing the same VCN default security list, causing a race condition on `terraform apply`:

1. **`module.vcn[0].oci_core_default_security_list.lockdown`** — created by the upstream `oracle-terraform-modules/vcn/oci` module when `lockdown_default_seclist = true`. It zeroes out all egress/ingress rules and uses `ignore_changes` on them.
2. **`oci_core_default_security_list.dd_default`** — our resource that sets egress-all + minimal ICMP ingress (no SSH).

Both fired `UpdateSecurityList` PUTs within ~150 ms during apply (confirmed in OCI audit logs). When the upstream lockdown resource won the race, all egress rules were wiped. Functions could no longer reach OCIR to pull their images, and every Service Connector Hub invocation returned:

```
{"code":"FunctionInvokeImageNotAvailable","message":"Failed to pull function image"}  (502)
```

With `lockdown_default_seclist = false`, the upstream module never creates the conflicting resource. `dd_default` becomes the sole owner of the default security list with the correct rules — preserving the security posture from PR #99 (no SSH ingress, egress-all for OCIR reachability).

Fixes #109