### PR TITLE
ECI-1626: pre_check.py quota checks block idempotent re-apply

### DIFF
--- a/datadog-integration/main.tf
+++ b/datadog-integration/main.tf
@@ -189,7 +189,8 @@ resource "null_resource" "precheck_marker" {
         --dg-fn-name '${local.dg_fn_name}' \
         --dg-policy-name '${local.dg_policy_name}' \
         --domain-display-name '${local.domain_display_name}' \
-        --idcs-endpoint '${local.idcs_endpoint}'
+        --idcs-endpoint '${local.idcs_endpoint}' \
+        --compartment-id '${var.compartment_id != null ? var.compartment_id : ""}'
     EOT
   }
 }

--- a/datadog-integration/pre_check.py
+++ b/datadog-integration/pre_check.py
@@ -8,7 +8,8 @@ OK_STATUS = "ok"
 ERROR_STATUS = "error"
 DEFAULT_DOMAIN_NAME = "Default"
 MIN_AVAILABLE_VAULT = 1
-MIN_AVAILABLE_CONNECTOR_HUB = 1
+DATADOG_VAULT_NAME = "datadog-vault"
+DATADOG_COMPARTMENT_NAME = "Datadog"
 
 class ResourceType(Enum):
     USER = "user"
@@ -83,7 +84,39 @@ def validate_pre_existing_resources(params, domain_endpoint):
         return f"{', '.join(existing)} already exists."
     return OK_STATUS
 
-def validate_vault_quota(tenancy_ocid, home_region):
+def _vault_exists(tenancy_ocid, home_region, compartment_id):
+    """Return True if the datadog-vault already exists, so re-apply does not trip the quota check."""
+    if not compartment_id:
+        # Look up the auto-created Datadog compartment under the tenancy.
+        try:
+            cmd = [
+                "oci", "iam", "compartment", "list",
+                "--compartment-id", tenancy_ocid,
+                "--name", DATADOG_COMPARTMENT_NAME,
+                "--query", "data[?\"lifecycle-state\"=='ACTIVE'].id | [0]",
+                "--raw-output",
+            ]
+            compartment_id = subprocess.check_output(cmd).decode().strip()
+        except Exception:
+            return False
+    if not compartment_id or compartment_id == "null":
+        return False
+    try:
+        cmd = [
+            "oci", "kms", "management", "vault", "list",
+            "--compartment-id", compartment_id,
+            "--region", home_region,
+            "--query", f"data[?\"display-name\"=='{DATADOG_VAULT_NAME}' && \"lifecycle-state\"=='ACTIVE'] | [0]",
+            "--raw-output",
+        ]
+        result = subprocess.check_output(cmd).decode().strip()
+        return bool(result and result != "null")
+    except Exception:
+        return False
+
+def validate_vault_quota(tenancy_ocid, home_region, compartment_id):
+    if _vault_exists(tenancy_ocid, home_region, compartment_id):
+        return OK_STATUS
     cmd = [
         "oci", "limits", "resource-availability", "get",
         "--service-name", "kms",
@@ -101,24 +134,6 @@ def validate_vault_quota(tenancy_ocid, home_region):
     except Exception as e:
         return f"Failed to check vault quota: {str(e)}"
 
-def validate_connector_hub_quota(tenancy_ocid, home_region):
-    cmd = [
-        "oci", "limits", "resource-availability", "get",
-        "--service-name", "service-connector-hub",
-        "--limit-name", "service-connector-count",
-        "--compartment-id", tenancy_ocid,
-        "--region", home_region
-    ]
-    try:
-        result = subprocess.check_output(cmd).decode()
-        data = json.loads(result)
-        available = data["data"].get("available", 0)
-        if available < MIN_AVAILABLE_CONNECTOR_HUB:
-            return f"Insufficient connector hub quota in region {home_region}: {available} available, {MIN_AVAILABLE_CONNECTOR_HUB} required."
-    except Exception as e:
-        return f"Failed to check connector hub quota in region {home_region}: {str(e)}"
-    return OK_STATUS
-
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--tenancy-id", required=True)
@@ -134,6 +149,7 @@ def parse_args():
     parser.add_argument("--dg-policy-name", required=True)
     parser.add_argument("--domain-display-name", required=True)
     parser.add_argument("--idcs-endpoint", required=True)
+    parser.add_argument("--compartment-id", required=False, default="")
     return parser.parse_args()
 
 def main():
@@ -152,6 +168,7 @@ def main():
         "dg_policy_name": args.dg_policy_name,
         "domain_display_name": args.domain_display_name,
         "idcs_endpoint": args.idcs_endpoint,
+        "compartment_id": args.compartment_id,
     }
 
     errors = []
@@ -180,13 +197,8 @@ def main():
     else:
         errors.append("User not found in any domain")
 
-    # Validation 5: Vault quota check
-    result = validate_vault_quota(params["tenancy_id"], params["home_region"])
-    if result != OK_STATUS:
-        errors.append(result)
-
-    # Validation 6: Connector hub quota check
-    result = validate_connector_hub_quota(params["tenancy_id"], params["home_region"])
+    # Validation 5: Vault quota check (skipped when vault already exists — idempotent re-apply)
+    result = validate_vault_quota(params["tenancy_id"], params["home_region"], params["compartment_id"])
     if result != OK_STATUS:
         errors.append(result)
 

--- a/datadog-integration/pre_check.py
+++ b/datadog-integration/pre_check.py
@@ -72,13 +72,15 @@ def validate_pre_existing_resources(params, domain_endpoint):
         existing.append(f"User {params['user_name']}")
     if _resource_exists(ResourceType.GROUP, params["user_group_name"], domain_endpoint=domain_endpoint):
         existing.append(f"User Group {params['user_group_name']}")
-    if _resource_exists(ResourceType.POLICY, params["user_group_policy_name"], compartment_id=params["tenancy_id"]):
+    if _resource_exists(ResourceType.POLICY, params["user_group_policy_name"], compartment_id=params["tenancy_id"]) \
+            and not _policy_owned_by_datadog(params["user_group_policy_name"], params["tenancy_id"]):
         existing.append(f"User Group Policy {params['user_group_policy_name']}")
     if _resource_exists(ResourceType.DYNAMIC_GROUP, params["dg_sch_name"], domain_endpoint=domain_endpoint):
         existing.append(f"Dynamic Group {params['dg_sch_name']}")
     if _resource_exists(ResourceType.DYNAMIC_GROUP, params["dg_fn_name"], domain_endpoint=domain_endpoint):
         existing.append(f"Dynamic Group {params['dg_fn_name']}")
-    if _resource_exists(ResourceType.POLICY, params["dg_policy_name"], compartment_id=params["tenancy_id"]):
+    if _resource_exists(ResourceType.POLICY, params["dg_policy_name"], compartment_id=params["tenancy_id"]) \
+            and not _policy_owned_by_datadog(params["dg_policy_name"], params["tenancy_id"]):
         existing.append(f"Dynamic Group Policy {params['dg_policy_name']}")
     if existing:
         return f"{', '.join(existing)} already exists."
@@ -111,6 +113,24 @@ def _vault_exists(tenancy_ocid, home_region, compartment_id):
         ]
         result = subprocess.check_output(cmd).decode().strip()
         return bool(result and result != "null")
+    except Exception:
+        return False
+
+def _policy_owned_by_datadog(name, compartment_id):
+    """Return True if the named IAM policy exists and carries the ownedby=datadog tag."""
+    cmd = [
+        "oci", "iam", "policy", "list",
+        "--compartment-id", compartment_id,
+        "--all",
+        "--query", f"data[?name=='{name}'] | [0]",
+        "--raw-output",
+    ]
+    try:
+        result = subprocess.check_output(cmd).decode().strip()
+        if not result or result == "null":
+            return False
+        policy = json.loads(result)
+        return policy.get("freeform-tags", {}).get("ownedby") == "datadog"
     except Exception:
         return False
 


### PR DESCRIPTION
Mirrors the fix from PR #114 (datadog-terraform-onboarding/prechecks.tf) for the datadog-integration / ORM stack flow.

## Changes

- **validate_vault_quota**: short-circuit when `datadog-vault` already exists in OCI (looked up via `oci kms management vault list` in the resolved compartment). On a re-apply where the vault was created by a prior apply the per-region virtual-vault-count quota is already consumed, so the raw quota check would incorrectly abort. The fix passes when quota >= 1 **or** the vault already exists.

- **validate_connector_hub_quota**: removed. The service connector is created by the regional OCI Resource Manager nested stacks (datadog-oci-orm/metrics-setup), not by this stack — the check guarded a resource it doesn't manage, exactly as #114 noted for the Terraform-onboarding path.

- **validate_pre_existing_resources** (policy checks): on re-apply, `dd-svc-policy` and `dd-dynamic-group-policy` already exist in OCI because Terraform created them on the first apply. The pre-check was erroring unconditionally on their existence. Fix adds `_policy_owned_by_datadog()` which inspects the `freeform-tags.ownedby` tag that the auth module stamps on every IAM policy it creates. A policy is only flagged as a collision if it exists **and** lacks that tag — i.e. it wasn't created by this stack.

- **main.tf**: pass `--compartment-id` to pre_check.py so the vault lookup works both when the user supplies an existing compartment and when the stack auto-creates one named "Datadog".

## Out of scope

The IDCS resource checks (user, group, dynamic groups) in `validate_pre_existing_resources` have the same re-apply false positive risk in theory, but are unaffected in practice for most tenancies because the dynamic group resources currently carry no ownership tags in the auth module. That fix is deferred to a follow-up.