### PR TITLE
feat: dd-octo-sts trust policy for release workflow

### DIFF
--- a/.github/chainguard/self.github.release.main.sts.yaml
+++ b/.github/chainguard/self.github.release.main.sts.yaml
@@ -1,0 +1,12 @@
+# Policy for: .github/workflows/release.yml in DataDog/oracle-cloud-integration
+issuer: https://token.actions.githubusercontent.com
+subject: repo:DataDog/oracle-cloud-integration:ref:refs/heads/master
+
+claim_pattern:
+  event_name: workflow_dispatch
+  job_workflow_ref: DataDog/oracle-cloud-integration/\.github/workflows/release\.yml@refs/heads/master
+  ref: refs/heads/master
+  repository: DataDog/oracle-cloud-integration
+
+permissions:
+  contents: write


### PR DESCRIPTION
## What

- Adds `.github/chainguard/self.github.release.main.sts.yaml` — a dd-octo-sts trust policy that allows the release workflow to exchange an OIDC token for a short-lived GitHub App token with `contents: write`
- Policy is restricted to `workflow_dispatch` events on `master` with four claim pattern fields for defense in depth
- `master` is protected by org-level rulesets, satisfying the requirement that `contents: write` be gated on a protected ref

## Why

Tag protection rules block manual tag creation. This policy is the prerequisite for the automated release workflow.
https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/6360924697/GitHub+Org-wide+Tag+Protection

## Merge order

**This PR must be merged to `master` before the release workflow PR** (`yu.hu/create-release-workflow`), because dd-octo-sts reads the trust policy from the default branch at token exchange time.

## Test plan

- [x] "Trust Policy Validation" CI check passes on this PR
- [x] Merge to `master`
- [ ] Then merge the release workflow PR and trigger a test release

🤖 Generated with [Claude Code](https://claude.com/claude-code)