### PR TITLE
feat: release workflow using dd-octo-sts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,14 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version tag to create (e.g. datadog-oci-orm-v1.6.0)"
+      bump:
+        description: "Version component to bump"
         required: true
-        type: string
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   release:
@@ -20,23 +24,43 @@ jobs:
           scope: DataDog/oracle-cloud-integration
           policy: self.github.release.main
 
-      - name: Validate version format
+      - name: Compute next version
+        id: version
         env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          if [[ ! "$VERSION" =~ ^datadog-oci-orm-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "ERROR: Invalid version format: $VERSION"
-            echo "Expected: datadog-oci-orm-vX.Y.Z"
-            exit 1
-          fi
-
-      - name: Create tag and GitHub release
-        env:
-          VERSION: ${{ inputs.version }}
+          BUMP: ${{ inputs.bump }}
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          # Create tag via API to avoid git credential issues (no checkout needed)
+          latest=$(gh api "repos/${GH_REPO}/tags" --jq '.[].name' \
+            | grep -E '^datadog-oci-orm-v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -t. -k1,1 -k2,2n -k3,3n \
+            | tail -1)
+
+          if [[ -z "$latest" ]]; then
+            echo "ERROR: no existing tag matching datadog-oci-orm-vX.Y.Z found"
+            exit 1
+          fi
+
+          ver="${latest#datadog-oci-orm-v}"
+          major="${ver%%.*}"; rest="${ver#*.}"
+          minor="${rest%%.*}"; patch="${rest#*.}"
+
+          case "$BUMP" in
+            major) major=$((major+1)); minor=0; patch=0 ;;
+            minor) minor=$((minor+1)); patch=0 ;;
+            patch) patch=$((patch+1)) ;;
+          esac
+
+          next="datadog-oci-orm-v${major}.${minor}.${patch}"
+          echo "Previous: $latest  →  Next: $next"
+          echo "version=$next" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag and GitHub release
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
           gh api "repos/${GH_REPO}/git/refs" \
             --method POST \
             --raw-field "ref=refs/tags/${VERSION}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,14 @@ jobs:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          latest=$(gh api "repos/${GH_REPO}/tags" --jq '.[].name' \
+          if [[ "$GITHUB_REF" != "refs/heads/master" ]]; then
+            echo "ERROR: release workflow must run from master (got $GITHUB_REF)"
+            exit 1
+          fi
+
+          latest=$(gh api "repos/${GH_REPO}/tags" --paginate --jq '.[].name' \
             | grep -E '^datadog-oci-orm-v[0-9]+\.[0-9]+\.[0-9]+$' \
-            | sort -t. -k1,1 -k2,2n -k3,3n \
+            | sort -V \
             | tail -1)
 
           if [[ -z "$latest" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,12 @@ jobs:
             --raw-field "ref=refs/tags/${VERSION}" \
             --raw-field "sha=${GITHUB_SHA}"
 
-          gh release create "${VERSION}" \
+          if ! gh release create "${VERSION}" \
             --repo "${GH_REPO}" \
             --title "${VERSION}" \
             --generate-notes \
-            --verify-tag
+            --verify-tag; then
+            echo "Release creation failed — deleting orphan tag ${VERSION}"
+            gh api "repos/${GH_REPO}/git/refs/tags/${VERSION}" --method DELETE
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,16 @@ jobs:
             exit 1
           fi
 
+          tag_obj=$(gh api "repos/${GH_REPO}/git/ref/tags/${latest}")
+          tag_sha=$(echo "$tag_obj" | jq -r '.object.sha')
+          if [[ "$(echo "$tag_obj" | jq -r '.object.type')" == "tag" ]]; then
+            tag_sha=$(gh api "repos/${GH_REPO}/git/tags/${tag_sha}" --jq '.object.sha')
+          fi
+          if [[ "$tag_sha" == "$GITHUB_SHA" ]]; then
+            echo "Nothing to release: HEAD is already tagged as ${latest}"
+            exit 0
+          fi
+
           ver="${latest#datadog-oci-orm-v}"
           major="${ver%%.*}"; rest="${ver#*.}"
           minor="${rest%%.*}"; patch="${rest#*.}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
           - patch
           - minor
           - major
+      dry_run:
+        description: "Dry run: build and upload assets to a draft release, then delete it. An ephemeral tag is created and deleted."
+        type: boolean
+        default: false
 
 jobs:
   release:
@@ -46,16 +50,6 @@ jobs:
             exit 1
           fi
 
-          tag_obj=$(gh api "repos/${GH_REPO}/git/ref/tags/${latest}")
-          tag_sha=$(echo "$tag_obj" | jq -r '.object.sha')
-          if [[ "$(echo "$tag_obj" | jq -r '.object.type')" == "tag" ]]; then
-            tag_sha=$(gh api "repos/${GH_REPO}/git/tags/${tag_sha}" --jq '.object.sha')
-          fi
-          if [[ "$tag_sha" == "$GITHUB_SHA" ]]; then
-            echo "Nothing to release: HEAD is already tagged as ${latest}"
-            exit 0
-          fi
-
           ver="${latest#datadog-oci-orm-v}"
           major="${ver%%.*}"; rest="${ver#*.}"
           minor="${rest%%.*}"; patch="${rest#*.}"
@@ -72,6 +66,7 @@ jobs:
 
       - name: Create tag
         id: create-tag
+        if: inputs.dry_run == false
         env:
           VERSION: ${{ steps.version.outputs.version }}
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
@@ -88,13 +83,26 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           GH_REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          gh release create "${VERSION}" \
-            --repo "${GH_REPO}" \
-            --title "${VERSION}" \
-            --generate-notes \
-            --verify-tag \
-            --latest=false
+          if [[ "$DRY_RUN" == "true" ]]; then
+            gh release create "${VERSION}" \
+              --repo "${GH_REPO}" \
+              --title "${VERSION}" \
+              --generate-notes \
+              --target "${GITHUB_SHA}" \
+              --draft \
+              --latest=false \
+              --fail-on-no-commits
+          else
+            gh release create "${VERSION}" \
+              --repo "${GH_REPO}" \
+              --title "${VERSION}" \
+              --generate-notes \
+              --verify-tag \
+              --latest=false \
+              --fail-on-no-commits
+          fi
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -113,12 +121,22 @@ jobs:
             --repo "${GH_REPO}"
 
       - name: Mark as latest
+        if: inputs.dry_run == false
         env:
           VERSION: ${{ steps.version.outputs.version }}
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           GH_REPO: ${{ github.repository }}
         run: |
           gh release edit "${VERSION}" --latest --repo "${GH_REPO}"
+
+      - name: Delete draft release and tag
+        if: always() && inputs.dry_run == true && steps.create-release.conclusion == 'success'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release delete "${VERSION}" --repo "${GH_REPO}" --yes --cleanup-tag
 
       - name: Delete release and tag on failure
         if: steps.create-tag.conclusion == 'success' && failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,8 @@ jobs:
           echo "Previous: $latest  →  Next: $next"
           echo "version=$next" >> "$GITHUB_OUTPUT"
 
-      - name: Create tag and GitHub release
+      - name: Create tag
+        id: create-tag
         env:
           VERSION: ${{ steps.version.outputs.version }}
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
@@ -81,12 +82,23 @@ jobs:
             --raw-field "ref=refs/tags/${VERSION}" \
             --raw-field "sha=${GITHUB_SHA}"
 
-          if ! gh release create "${VERSION}" \
+      - name: Create release
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release create "${VERSION}" \
             --repo "${GH_REPO}" \
             --title "${VERSION}" \
             --generate-notes \
-            --verify-tag; then
-            echo "Release creation failed — deleting orphan tag ${VERSION}"
-            gh api "repos/${GH_REPO}/git/refs/tags/${VERSION}" --method DELETE
-            exit 1
-          fi
+            --verify-tag
+
+      - name: Delete orphan tag on failure
+        if: steps.create-tag.conclusion == 'success' && failure()
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/${GH_REPO}/git/refs/tags/${VERSION}" --method DELETE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
             --raw-field "sha=${GITHUB_SHA}"
 
       - name: Create release
+        id: create-release
         env:
           VERSION: ${{ steps.version.outputs.version }}
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
@@ -92,13 +93,39 @@ jobs:
             --repo "${GH_REPO}" \
             --title "${VERSION}" \
             --generate-notes \
-            --verify-tag
+            --verify-tag \
+            --latest=false
 
-      - name: Delete orphan tag on failure
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build artifacts
+        run: |
+          cd datadog-integration && zip -r ../datadog-integration.zip ./* && cd ..
+
+      - name: Upload assets
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release upload "${VERSION}" datadog-integration.zip \
+            --repo "${GH_REPO}"
+
+      - name: Mark as latest
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release edit "${VERSION}" --latest --repo "${GH_REPO}"
+
+      - name: Delete release and tag on failure
         if: steps.create-tag.conclusion == 'success' && failure()
         env:
           VERSION: ${{ steps.version.outputs.version }}
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           GH_REPO: ${{ github.repository }}
         run: |
+          gh release delete "${VERSION}" --repo "${GH_REPO}" --yes || true
           gh api "repos/${GH_REPO}/git/refs/tags/${VERSION}" --method DELETE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,8 +108,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Build artifacts
-        run: |
-          cd datadog-integration && zip -r ../datadog-integration.zip ./* && cd ..
+        working-directory: datadog-integration
+        run: zip -r ../datadog-integration.zip ./*
 
       - name: Upload assets
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag to create (e.g. datadog-oci-orm-v1.6.0)"
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # required for dd-octo-sts OIDC token exchange
+    steps:
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/oracle-cloud-integration
+          policy: self.github.release.main
+
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^datadog-oci-orm-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: Invalid version format: $VERSION"
+            echo "Expected: datadog-oci-orm-vX.Y.Z"
+            exit 1
+          fi
+
+      - name: Create tag and GitHub release
+        env:
+          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # Create tag via API to avoid git credential issues (no checkout needed)
+          gh api "repos/${GH_REPO}/git/refs" \
+            --method POST \
+            --raw-field "ref=refs/tags/${VERSION}" \
+            --raw-field "sha=${GITHUB_SHA}"
+
+          gh release create "${VERSION}" \
+            --repo "${GH_REPO}" \
+            --title "${VERSION}" \
+            --generate-notes \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,5 +145,5 @@ jobs:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          gh release delete "${VERSION}" --repo "${GH_REPO}" --yes || true
-          gh api "repos/${GH_REPO}/git/refs/tags/${VERSION}" --method DELETE
+          gh release delete "${VERSION}" --repo "${GH_REPO}" --yes --cleanup-tag 2>/dev/null || \
+            gh api "repos/${GH_REPO}/git/refs/tags/${VERSION}" --method DELETE


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` — a `workflow_dispatch` workflow that automates releases by pushing tags and creating GitHub releases via dd-octo-sts
- Replaces manual tag creation, which is blocked by tag protection rules
- Accepts a `bump` input (patch/minor/major) and auto-computes the next version from the latest `datadog-oci-orm-vX.Y.Z` tag
- Tag and release are created via the GitHub API using a short-lived dd-octo-sts token (no checkout needed)

## Why

Tag protection rules block manual tag creation. The workflow exchanges a short-lived OIDC token for a GitHub App token with `contents: write` scoped to this repo via dd-octo-sts, bypassing the protection in a controlled, auditable way.

## Merge order

**Requires the trust policy PR (#117) to be merged to `master` first.** dd-octo-sts reads the trust policy from the default branch at token exchange time.

## Known limitation

If tag creation succeeds but `gh release create` fails, retrying will compute the next version from the newly-created orphan tag, skipping a version number. Delete the orphan tag before retrying in that case.

## Test plan

- [x] Merge PR #117 (trust policy) to `master`
- [ ] Merge this PR to `master`
- [ ] Go to Actions → Release → Run workflow, select `patch`
- [ ] Confirm new tag `datadog-oci-orm-v1.1.7` and release are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)