### PR TITLE
ECI-1625: (fix) add depends_on to prevent race condition in default security list

### DIFF
--- a/datadog-integration/modules/regional-stacks/main.tf
+++ b/datadog-integration/modules/regional-stacks/main.tf
@@ -75,6 +75,7 @@ module "subnet" {
 resource "oci_core_default_security_list" "dd_default" {
   count                      = var.subnet_ocid == "" ? 1 : 0
   manage_default_resource_id = data.oci_core_vcn.dd_vcn[0].default_security_list_id
+  depends_on                 = [module.vcn]
   freeform_tags              = var.tags
 
   egress_security_rules {

--- a/datadog-terraform-onboarding/modules/regional-stacks/main.tf
+++ b/datadog-terraform-onboarding/modules/regional-stacks/main.tf
@@ -77,6 +77,7 @@ module "subnet" {
 resource "oci_core_default_security_list" "dd_default" {
   count                      = var.subnet_ocid == "" ? 1 : 0
   manage_default_resource_id = data.oci_core_vcn.dd_vcn[0].default_security_list_id
+  depends_on                 = [module.vcn]
   freeform_tags              = var.tags
 
   egress_security_rules {


### PR DESCRIPTION
## What

Add `depends_on = [module.vcn]` to `oci_core_default_security_list.dd_default` in both `datadog-integration` and `datadog-terraform-onboarding` regional-stacks modules.

## Why

PR #99 (CLOUDS-7599) introduced a race condition where two Terraform resources simultaneously manage the same VCN default security list via `manage_default_resource_id`:

- **Resource 1**: `module.vcn[0]` (upstream `oracle-terraform-modules/vcn/oci`) internally creates `oci_core_default_security_list.lockdown`, which writes **empty rules** (no egress, no ingress) and has `lifecycle { ignore_changes = [...] }`.
- **Resource 2**: `oci_core_default_security_list.dd_default` — writes the correct minimal rules: egress-all (required for OCIR image pulls) + two ICMP-only ingress rules.

Both target the same security list ID. The OCI audit log shows two `UpdateSecurityList` calls ~158ms apart during apply. If `lockdown` wins the race, the list is left with empty egress — functions cannot reach OCIR → 502 `FunctionInvokeImageNotAvailable`. Because `lockdown` has `ignore_changes`, Terraform won't self-correct on subsequent applies.

`depends_on = [module.vcn]` enforces ordering: the entire VCN module (including its hidden `lockdown` resource) completes before `dd_default` writes the correct rules. Since `lockdown` has `ignore_changes`, it won't overwrite `dd_default` afterward.

## References

- Jira: [ECI-1625](https://datadoghq.atlassian.net/browse/ECI-1625)
- GitHub issue: #109
- Introducing PR: #99