### PR TITLE
Fix dry-run release workflow: remove --cleanup-tag from draft delete

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
           - minor
           - major
       dry_run:
-        description: "Dry run: build and upload assets to a draft release, then delete it. An ephemeral tag is created and deleted."
+        description: "Dry run: build and upload assets to a draft release, then delete it."
         type: boolean
         default: false
 
@@ -129,14 +129,14 @@ jobs:
         run: |
           gh release edit "${VERSION}" --latest --repo "${GH_REPO}"
 
-      - name: Delete draft release and tag
+      - name: Delete draft release
         if: always() && inputs.dry_run == true && steps.create-release.conclusion == 'success'
         env:
           VERSION: ${{ steps.version.outputs.version }}
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          gh release delete "${VERSION}" --repo "${GH_REPO}" --yes --cleanup-tag
+          gh release delete "${VERSION}" --repo "${GH_REPO}" --yes
 
       - name: Delete release and tag on failure
         if: steps.create-tag.conclusion == 'success' && failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,16 +41,16 @@ jobs:
           fi
 
           latest=$(gh api "repos/${GH_REPO}/tags" --paginate --jq '.[].name' \
-            | grep -E '^datadog-oci-orm-v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | grep -E '^datadog-integration-v[0-9]+\.[0-9]+\.[0-9]+$' \
             | sort -V \
             | tail -1)
 
           if [[ -z "$latest" ]]; then
-            echo "ERROR: no existing tag matching datadog-oci-orm-vX.Y.Z found"
+            echo "ERROR: no existing tag matching datadog-integration-vX.Y.Z found"
             exit 1
           fi
 
-          ver="${latest#datadog-oci-orm-v}"
+          ver="${latest#datadog-integration-v}"
           major="${ver%%.*}"; rest="${ver#*.}"
           minor="${rest%%.*}"; patch="${rest#*.}"
 
@@ -60,7 +60,7 @@ jobs:
             patch) patch=$((patch+1)) ;;
           esac
 
-          next="datadog-oci-orm-v${major}.${minor}.${patch}"
+          next="datadog-integration-v${major}.${minor}.${patch}"
           echo "Previous: $latest  →  Next: $next"
           echo "version=$next" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

- Remove `--cleanup-tag` from the dry-run delete step: GitHub does not create a tag for draft releases, so the flag was failing with `HTTP 422: Reference does not exist`
- Switch version prefix from `datadog-oci-orm-v` to `datadog-integration-v`: the `datadog-oci-orm-v` series had a stray `v1.5.5` tag that was causing the next computed version to jump to `v1.5.6` instead of continuing from the intended `v1.1.x` series; the `datadog-integration-v` tags top out at `v1.1.4` so the next release will be `v1.1.5`

## Root cause (dry-run failure)

Run [#25396494703](https://github.com/DataDog/oracle-cloud-integration/actions/runs/25396494703/job/74484581467) failed at "Delete draft release and tag" with:
```
HTTP 422: Reference does not exist (https://api.github.com/repos/DataDog/oracle-cloud-integration/git/refs/tags/datadog-oci-orm-v1.5.6)
```

The draft release was created successfully and deleted, but `--cleanup-tag` blew up since no tag ever existed (draft releases don't create tags, and "Create tag" is intentionally skipped in dry-run mode).

## Test plan

- [ ] Run the release workflow with `dry_run: true` and confirm it completes successfully with version `datadog-integration-v1.1.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)