### PR TITLE
fix: OCI identity domain detection — v.id, direct fetch, email inference

### DIFF
--- a/datadog-integration/data.tf
+++ b/datadog-integration/data.tf
@@ -39,3 +39,12 @@ data "oci_identity_domain" "domain" {
   domain_id = local.matching_domain_id
 }
 
+# Used when an explicit domain_id is provided so email can be inferred directly
+# from that domain rather than the all_domains-derived map, which only covers
+# domains in the tenancy root compartment.
+data "oci_identity_domains_user" "user_in_explicit_domain" {
+  count         = var.domain_id != null && var.domain_id != "" && (var.existing_user_id == null || var.existing_user_id == "") ? 1 : 0
+  idcs_endpoint = data.oci_identity_domain.domain.url
+  user_id       = var.current_user_ocid
+}
+

--- a/datadog-integration/data.tf
+++ b/datadog-integration/data.tf
@@ -43,7 +43,11 @@ data "oci_identity_domain" "domain" {
 # from that domain rather than the all_domains-derived map, which only covers
 # domains in the tenancy root compartment.
 data "oci_identity_domains_user" "user_in_explicit_domain" {
-  count         = var.domain_id != null && var.domain_id != "" && (var.existing_user_id == null || var.existing_user_id == "") ? 1 : 0
+  count = (
+    var.domain_id != null && var.domain_id != "" &&
+    (var.existing_user_id == null || var.existing_user_id == "") &&
+    (var.user_email == null || var.user_email == "")
+  ) ? 1 : 0
   idcs_endpoint = data.oci_identity_domain.domain.url
   user_id       = var.current_user_ocid
 }

--- a/datadog-integration/locals.tf
+++ b/datadog-integration/locals.tf
@@ -55,7 +55,9 @@ locals {
         [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null][0] :
         null
       ) :
-      # If no user or group is specified, find the domain associated with the current user
+      # If no user or group is specified, find the domain associated with the current user.
+      # Note: all_domains only lists domains in the tenancy root compartment. If the
+      # domain is in a child compartment, provide domain_id explicitly.
       (
         length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null]) > 0 ?
         [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null][0] :
@@ -72,8 +74,12 @@ locals {
         var.existing_user_id != null && var.existing_user_id != "" ? (
           null
         ):
-          # If no user is specified, infer the email from the current logged in user
-          data.oci_identity_domains_user.user_in_domain[local.matching_domain_id].emails[0].value
+          # If no user is specified, infer the email from the current logged in user.
+          # When domain_id is explicitly provided, use the direct lookup so child-compartment
+          # domains (absent from the all_domains map) don't cause an invalid key error.
+          var.domain_id != null && var.domain_id != "" ?
+            data.oci_identity_domains_user.user_in_explicit_domain[0].emails[0].value :
+            data.oci_identity_domains_user.user_in_domain[local.matching_domain_id].emails[0].value
       )
   )
 

--- a/datadog-integration/locals.tf
+++ b/datadog-integration/locals.tf
@@ -51,16 +51,16 @@ locals {
       # If a user and group are specified, find the associated domain
       var.existing_user_id != null && var.existing_user_id != "" ?
       (
-        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null][0] :
+        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null][0] :
         null
       ) :
       # If no user or group is specified, find the domain associated with the current user.
       # Note: all_domains only lists domains in the tenancy root compartment. If the
       # domain is in a child compartment, provide domain_id explicitly.
       (
-        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null][0] :
+        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null][0] :
         null
       )
     )

--- a/datadog-integration/locals.tf
+++ b/datadog-integration/locals.tf
@@ -51,23 +51,18 @@ locals {
       # If a user and group are specified, find the associated domain
       var.existing_user_id != null && var.existing_user_id != "" ?
       (
-        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null][0] :
+        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null][0] :
         null
       ) :
       # If no user or group is specified, find the domain associated with the current user
       (
-        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null][0] :
+        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null][0] :
         null
       )
     )
   )
-
-  matching_domain = [
-    for d in data.oci_identity_domains.all_domains.domains : d
-    if d.id == local.matching_domain_id
-  ][0]
 
   user_email = (
     # If the email is provided, use that
@@ -82,8 +77,8 @@ locals {
       )
   )
 
-  domain_display_name = local.matching_domain.display_name
-  idcs_endpoint       = local.matching_domain.url
+  domain_display_name = data.oci_identity_domain.domain.display_name
+  idcs_endpoint       = data.oci_identity_domain.domain.url
 
   actual_user_name  = (var.existing_user_id == null || var.existing_user_id == "") ? local.user_name : null
   actual_group_name = (var.existing_group_id == null || var.existing_group_id == "") ? local.user_group_name : null

--- a/datadog-oci-orm/policy-setup/data.tf
+++ b/datadog-oci-orm/policy-setup/data.tf
@@ -14,6 +14,6 @@ data "oci_identity_domains_user" "user_in_domain" {
 }
 
 locals {
-  matching_domain = data.oci_identity_user.current_user.email == null ? [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null][0] : null
+  matching_domain = data.oci_identity_user.current_user.email == null ? [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.emails != null][0] : null
   email           = data.oci_identity_user.current_user.email != null ? data.oci_identity_user.current_user.email : data.oci_identity_domains_user.user_in_domain[local.matching_domain].emails[0].value
 }

--- a/datadog-oci-orm/policy-setup/data.tf
+++ b/datadog-oci-orm/policy-setup/data.tf
@@ -14,6 +14,6 @@ data "oci_identity_domains_user" "user_in_domain" {
 }
 
 locals {
-  matching_domain = data.oci_identity_user.current_user.email == null ? [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.emails != null][0] : null
+  matching_domain = data.oci_identity_user.current_user.email == null ? [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null][0] : null
   email           = data.oci_identity_user.current_user.email != null ? data.oci_identity_user.current_user.email : data.oci_identity_domains_user.user_in_domain[local.matching_domain].emails[0].value
 }

--- a/datadog-terraform-onboarding/data.tf
+++ b/datadog-terraform-onboarding/data.tf
@@ -39,3 +39,12 @@ data "oci_identity_domain" "domain" {
   domain_id = local.matching_domain_id
 }
 
+# Used when an explicit domain_id is provided so email can be inferred directly
+# from that domain rather than the all_domains-derived map, which only covers
+# domains in the tenancy root compartment.
+data "oci_identity_domains_user" "user_in_explicit_domain" {
+  count         = var.domain_id != null && var.domain_id != "" && (var.existing_user_id == null || var.existing_user_id == "") ? 1 : 0
+  idcs_endpoint = data.oci_identity_domain.domain.url
+  user_id       = var.current_user_ocid
+}
+

--- a/datadog-terraform-onboarding/data.tf
+++ b/datadog-terraform-onboarding/data.tf
@@ -43,7 +43,11 @@ data "oci_identity_domain" "domain" {
 # from that domain rather than the all_domains-derived map, which only covers
 # domains in the tenancy root compartment.
 data "oci_identity_domains_user" "user_in_explicit_domain" {
-  count         = var.domain_id != null && var.domain_id != "" && (var.existing_user_id == null || var.existing_user_id == "") ? 1 : 0
+  count = (
+    var.domain_id != null && var.domain_id != "" &&
+    (var.existing_user_id == null || var.existing_user_id == "") &&
+    (var.user_email == null || var.user_email == "")
+  ) ? 1 : 0
   idcs_endpoint = data.oci_identity_domain.domain.url
   user_id       = var.current_user_ocid
 }

--- a/datadog-terraform-onboarding/locals.tf
+++ b/datadog-terraform-onboarding/locals.tf
@@ -40,23 +40,20 @@ locals {
       # If a user and group are specified, find the associated domain
       var.existing_user_id != null && var.existing_user_id != "" ?
       (
-        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null][0] :
+        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null][0] :
         null
       ) :
-      # If no user or group is specified, find the domain associated with the current user
+      # If no user or group is specified, find the domain associated with the current user.
+      # Note: all_domains only lists domains in the tenancy root compartment. If the
+      # domain is in a child compartment, provide domain_id explicitly.
       (
-        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null][0] :
+        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null][0] :
         null
       )
     )
   )
-
-  matching_domain = [
-    for d in data.oci_identity_domains.all_domains.domains : d
-    if d.id == local.matching_domain_id
-  ][0]
 
   user_email = (
     # If the email is provided, use that
@@ -66,13 +63,17 @@ locals {
         var.existing_user_id != null && var.existing_user_id != "" ? (
           null
         ):
-          # If no user is specified, infer the email from the current logged in user
-          data.oci_identity_domains_user.user_in_domain[local.matching_domain_id].emails[0].value
+          # If no user is specified, infer the email from the current logged in user.
+          # When domain_id is explicitly provided, use the direct lookup so child-compartment
+          # domains (absent from the all_domains map) don't cause an invalid key error.
+          var.domain_id != null && var.domain_id != "" ?
+            data.oci_identity_domains_user.user_in_explicit_domain[0].emails[0].value :
+            data.oci_identity_domains_user.user_in_domain[local.matching_domain_id].emails[0].value
       )
   )
 
-  domain_display_name = local.matching_domain.display_name
-  idcs_endpoint       = local.matching_domain.url
+  domain_display_name = data.oci_identity_domain.domain.display_name
+  idcs_endpoint       = data.oci_identity_domain.domain.url
 
   actual_user_name  = (var.existing_user_id == null || var.existing_user_id == "") ? local.user_name : null
   actual_group_name = (var.existing_group_id == null || var.existing_group_id == "") ? local.user_group_name : null

--- a/datadog-terraform-onboarding/locals.tf
+++ b/datadog-terraform-onboarding/locals.tf
@@ -40,16 +40,16 @@ locals {
       # If a user and group are specified, find the associated domain
       var.existing_user_id != null && var.existing_user_id != "" ?
       (
-        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null][0] :
+        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null][0] :
         null
       ) :
       # If no user or group is specified, find the domain associated with the current user.
       # Note: all_domains only lists domains in the tenancy root compartment. If the
       # domain is in a child compartment, provide domain_id explicitly.
       (
-        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null][0] :
+        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null][0] :
         null
       )
     )


### PR DESCRIPTION
## What

Fixes a customer-facing crash in OCI identity domain metadata lookup that occurs when the customer's identity domain lives in a child compartment (not the tenancy root).

## Root Cause

`oci_identity_domains` (plural) only queries one compartment — the tenancy root. OCI always provisions the Default domain there, but customers can create custom identity domains in child compartments. When a customer provides an explicit `domain_id` for a child-compartment domain, `local.matching_domain` filtered `all_domains` (root only) for display_name and url — that domain is absent, the filter returns empty, and `[0]` crashes with "collection has no elements."

The auto-detection path (blank `domain_id`) has the same limitation: `user_in_domain` iterates over root-compartment domains only, so a user whose domain is in a child compartment will not be found. Customers in this situation must provide `domain_id` explicitly (see remaining limitation below).

## Changes

- Removed `local.matching_domain` (filtered `all_domains`); replaced `domain_display_name` and `idcs_endpoint` with `data.oci_identity_domain.domain` which does a direct OCID fetch independent of compartment hierarchy
- Added `user_in_explicit_domain` data source for email inference when `domain_id` is explicit but `user_email` is blank — queries the resolved domain URL directly, bypassing the `all_domains`-derived map
- Applied to both `datadog-integration` and `datadog-terraform-onboarding`

## Remaining Limitation

When `domain_id` is left blank, auto-detection still only covers root-compartment domains. Customers whose identity domain is in a child compartment must provide `domain_id` explicitly.

## Test Plan

- [ ] Stack with explicit `domain_id` in child compartment — direct fetch should succeed where `all_domains` filter previously crashed
- [ ] Stack with explicit `domain_id` in root compartment — direct fetch + email inference via `user_in_explicit_domain`
- [ ] Stack with explicit `domain_id` + explicit `user_email` — `user_in_explicit_domain` count is 0, no unnecessary SCIM lookup
- [ ] Stack with blank `domain_id` (Default domain user) — auto-detection unchanged, still works

Related: CLOUDS-6584

🤖 Generated with [Claude Code](https://claude.com/claude-code)