### PR TITLE
feat: reuse existing dd-function-app on reapply when destroy left it behind

### DIFF
--- a/datadog-integration/data.tf
+++ b/datadog-integration/data.tf
@@ -39,3 +39,12 @@ data "oci_identity_domain" "domain" {
   domain_id = local.matching_domain_id
 }
 
+# Used when an explicit domain_id is provided so email can be inferred directly
+# from that domain rather than the all_domains-derived map, which only covers
+# domains in the tenancy root compartment.
+data "oci_identity_domains_user" "user_in_explicit_domain" {
+  count         = var.domain_id != null && var.domain_id != "" && (var.existing_user_id == null || var.existing_user_id == "") ? 1 : 0
+  idcs_endpoint = data.oci_identity_domain.domain.url
+  user_id       = var.current_user_ocid
+}
+

--- a/datadog-integration/data.tf
+++ b/datadog-integration/data.tf
@@ -43,7 +43,11 @@ data "oci_identity_domain" "domain" {
 # from that domain rather than the all_domains-derived map, which only covers
 # domains in the tenancy root compartment.
 data "oci_identity_domains_user" "user_in_explicit_domain" {
-  count         = var.domain_id != null && var.domain_id != "" && (var.existing_user_id == null || var.existing_user_id == "") ? 1 : 0
+  count = (
+    var.domain_id != null && var.domain_id != "" &&
+    (var.existing_user_id == null || var.existing_user_id == "") &&
+    (var.user_email == null || var.user_email == "")
+  ) ? 1 : 0
   idcs_endpoint = data.oci_identity_domain.domain.url
   user_id       = var.current_user_ocid
 }

--- a/datadog-integration/locals.tf
+++ b/datadog-integration/locals.tf
@@ -55,7 +55,9 @@ locals {
         [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null][0] :
         null
       ) :
-      # If no user or group is specified, find the domain associated with the current user
+      # If no user or group is specified, find the domain associated with the current user.
+      # Note: all_domains only lists domains in the tenancy root compartment. If the
+      # domain is in a child compartment, provide domain_id explicitly.
       (
         length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null]) > 0 ?
         [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null][0] :
@@ -72,8 +74,12 @@ locals {
         var.existing_user_id != null && var.existing_user_id != "" ? (
           null
         ):
-          # If no user is specified, infer the email from the current logged in user
-          data.oci_identity_domains_user.user_in_domain[local.matching_domain_id].emails[0].value
+          # If no user is specified, infer the email from the current logged in user.
+          # When domain_id is explicitly provided, use the direct lookup so child-compartment
+          # domains (absent from the all_domains map) don't cause an invalid key error.
+          var.domain_id != null && var.domain_id != "" ?
+            data.oci_identity_domains_user.user_in_explicit_domain[0].emails[0].value :
+            data.oci_identity_domains_user.user_in_domain[local.matching_domain_id].emails[0].value
       )
   )
 

--- a/datadog-integration/locals.tf
+++ b/datadog-integration/locals.tf
@@ -51,16 +51,16 @@ locals {
       # If a user and group are specified, find the associated domain
       var.existing_user_id != null && var.existing_user_id != "" ?
       (
-        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null][0] :
+        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null][0] :
         null
       ) :
       # If no user or group is specified, find the domain associated with the current user.
       # Note: all_domains only lists domains in the tenancy root compartment. If the
       # domain is in a child compartment, provide domain_id explicitly.
       (
-        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null][0] :
+        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null][0] :
         null
       )
     )

--- a/datadog-integration/locals.tf
+++ b/datadog-integration/locals.tf
@@ -51,23 +51,18 @@ locals {
       # If a user and group are specified, find the associated domain
       var.existing_user_id != null && var.existing_user_id != "" ?
       (
-        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null][0] :
+        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null][0] :
         null
       ) :
       # If no user or group is specified, find the domain associated with the current user
       (
-        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null][0] :
+        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null][0] :
         null
       )
     )
   )
-
-  matching_domain = [
-    for d in data.oci_identity_domains.all_domains.domains : d
-    if d.id == local.matching_domain_id
-  ][0]
 
   user_email = (
     # If the email is provided, use that
@@ -82,8 +77,8 @@ locals {
       )
   )
 
-  domain_display_name = local.matching_domain.display_name
-  idcs_endpoint       = local.matching_domain.url
+  domain_display_name = data.oci_identity_domain.domain.display_name
+  idcs_endpoint       = data.oci_identity_domain.domain.url
 
   actual_user_name  = (var.existing_user_id == null || var.existing_user_id == "") ? local.user_name : null
   actual_group_name = (var.existing_group_id == null || var.existing_group_id == "") ? local.user_group_name : null

--- a/datadog-integration/modules/regional-stacks/data.tf
+++ b/datadog-integration/modules/regional-stacks/data.tf
@@ -1,3 +1,9 @@
+data "oci_functions_applications" "existing_dd_function_app" {
+  compartment_id = var.compartment_ocid
+  display_name   = "dd-function-app"
+  state          = "ACTIVE"
+}
+
 data "http" "token_logs" {
   url = local.token_logs
 }
@@ -37,6 +43,6 @@ data "oci_core_subnet" "provided_subnet" {
 }
 
 data "oci_core_vcn" "dd_vcn" {
-  count  = var.subnet_ocid == "" ? 1 : 0
+  count  = local.create_network ? 1 : 0
   vcn_id = module.vcn[0].vcn_id
 }

--- a/datadog-integration/modules/regional-stacks/data.tf
+++ b/datadog-integration/modules/regional-stacks/data.tf
@@ -4,6 +4,24 @@ data "oci_functions_applications" "existing_dd_function_app" {
   state          = "ACTIVE"
 }
 
+check "adopted_app_config" {
+  # When an orphaned dd-function-app is adopted, Terraform cannot update its config
+  # (the resource is unmanaged). Warn if the key forwarding settings diverge from
+  # the current stack variables so the operator knows to update them manually via
+  # the OCI Console or CLI.
+  assert {
+    condition = (
+      local.existing_function_app_id == null ||
+      length(data.oci_functions_applications.existing_dd_function_app.applications) == 0 ||
+      (
+        lookup(data.oci_functions_applications.existing_dd_function_app.applications[0].config, "DD_SITE", "") == var.datadog_site &&
+        lookup(data.oci_functions_applications.existing_dd_function_app.applications[0].config, "API_KEY_SECRET_OCID", "") == var.api_key_secret_id
+      )
+    )
+    error_message = "Adopted dd-function-app config is stale: DD_SITE or API_KEY_SECRET_OCID differ from current stack variables. Update the application config manually via the OCI Console or with: oci fn application update --application-id ${coalesce(local.existing_function_app_id, "n/a")} --config '{...}'."
+  }
+}
+
 data "http" "token_logs" {
   url = local.token_logs
 }

--- a/datadog-integration/modules/regional-stacks/locals.tf
+++ b/datadog-integration/modules/regional-stacks/locals.tf
@@ -43,7 +43,10 @@ locals {
   # Using terraform_data rather than the data source directly avoids the idempotency
   # trap: without this freeze, the data source finds the app Terraform itself just
   # created, flips count to 0, and plans to destroy the managed app on the next apply.
-  existing_function_app_id = try(tostring(terraform_data.adopted_function_app_id.output), null)
+  #
+  # When var.subnet_ocid is explicitly provided we treat this as a fresh deploy and
+  # do NOT adopt the orphaned app, so the explicit subnet preference is honoured.
+  existing_function_app_id = var.subnet_ocid == "" ? try(tostring(terraform_data.adopted_function_app_id.output), null) : null
 
   # The application ID to attach Datadog functions to.
   # Prefers the orphaned app so the customer's custom function stays co-located with

--- a/datadog-integration/modules/regional-stacks/locals.tf
+++ b/datadog-integration/modules/regional-stacks/locals.tf
@@ -31,14 +31,37 @@ locals {
 
   # Subnet region validation when OCID is provided (handles both 3-letter codes and full names)
   subnet_region_from_ocid = var.subnet_ocid != "" ? split(".", var.subnet_ocid)[3] : ""
-  
+
   # Check if the region from OCID matches current region (either by full name or region key)
   # Convert extracted region to uppercase for comparison since region_key is uppercase
   subnet_region_matches = var.subnet_ocid == "" || (
-    local.subnet_region_from_ocid == var.region || 
+    local.subnet_region_from_ocid == var.region ||
     upper(local.subnet_region_from_ocid) == var.region_key
   )
-  
-  # Simple subnet selection logic: use provided OCID or create new
-  subnet_id = var.subnet_ocid != "" ? var.subnet_ocid : module.subnet[0].subnet_id[local.subnet]
+
+  # ID of an existing dd-function-app, frozen at first apply via terraform_data.
+  # Using terraform_data rather than the data source directly avoids the idempotency
+  # trap: without this freeze, the data source finds the app Terraform itself just
+  # created, flips count to 0, and plans to destroy the managed app on the next apply.
+  existing_function_app_id = try(tostring(terraform_data.adopted_function_app_id.output), null)
+
+  # The application ID to attach Datadog functions to.
+  # Prefers the orphaned app so the customer's custom function stays co-located with
+  # the Datadog forwarders.
+  function_app_id = coalesce(
+    local.existing_function_app_id,
+    one(oci_functions_application.dd_function_app[*].id)
+  )
+
+  # Only provision VCN/subnet when there is no existing app to inherit the network from
+  # and no explicit subnet OCID was provided.
+  create_network = local.existing_function_app_id == null && var.subnet_ocid == ""
+
+  # Subnet selection priority: explicit OCID → existing app's subnet → newly created subnet
+  subnet_id = (
+    var.subnet_ocid != "" ? var.subnet_ocid :
+    local.existing_function_app_id != null && length(data.oci_functions_applications.existing_dd_function_app.applications) > 0 ?
+      data.oci_functions_applications.existing_dd_function_app.applications[0].subnet_ids[0] :
+    module.subnet[0].subnet_id[local.subnet]
+  )
 }

--- a/datadog-integration/modules/regional-stacks/main.tf
+++ b/datadog-integration/modules/regional-stacks/main.tf
@@ -22,6 +22,7 @@ resource "terraform_data" "adopted_function_app_id" {
   }
 }
 
+
 resource "oci_functions_function" "logs_function" {
   application_id = local.function_app_id
   display_name   = "dd-logs-forwarder"

--- a/datadog-integration/modules/regional-stacks/main.tf
+++ b/datadog-integration/modules/regional-stacks/main.tf
@@ -12,8 +12,18 @@ terraform {
   }
 }
 
+resource "terraform_data" "adopted_function_app_id" {
+  # Captures the OCID of an orphaned dd-function-app (left behind by a failed destroy)
+  # at first apply, then freezes it. ignore_changes prevents the value from updating on
+  # subsequent plans when the data source starts returning the app Terraform itself created.
+  input = one(data.oci_functions_applications.existing_dd_function_app.applications[*].id)
+  lifecycle {
+    ignore_changes = [input]
+  }
+}
+
 resource "oci_functions_function" "logs_function" {
-  application_id = oci_functions_application.dd_function_app.id
+  application_id = local.function_app_id
   display_name   = "dd-logs-forwarder"
   memory_in_mbs  = "1024"
   freeform_tags  = var.tags
@@ -24,7 +34,7 @@ resource "oci_functions_function" "logs_function" {
 }
 
 resource "oci_functions_function" "metrics_function" {
-  application_id = oci_functions_application.dd_function_app.id
+  application_id = local.function_app_id
   display_name   = "dd-metrics-forwarder"
   memory_in_mbs  = "512"
   freeform_tags  = var.tags
@@ -34,7 +44,7 @@ resource "oci_functions_function" "metrics_function" {
 }
 
 module "vcn" {
-  count                    = var.subnet_ocid == "" ? 1 : 0
+  count                    = local.create_network ? 1 : 0
   source                   = "oracle-terraform-modules/vcn/oci"
   version                  = "3.6.0"
   compartment_id           = var.compartment_ocid
@@ -54,7 +64,7 @@ module "vcn" {
 
 # Same VCN module's subnet submodule; we call it directly so we can pass defined_tags (parent VCN module doesn't).
 module "subnet" {
-  count          = var.subnet_ocid == "" ? 1 : 0
+  count          = local.create_network ? 1 : 0
   source        = "oracle-terraform-modules/vcn/oci//modules/subnet"
   version       = "3.6.0"
   compartment_id = var.compartment_ocid
@@ -73,7 +83,7 @@ module "subnet" {
 }
 
 resource "oci_core_default_security_list" "dd_default" {
-  count                      = var.subnet_ocid == "" ? 1 : 0
+  count                      = local.create_network ? 1 : 0
   manage_default_resource_id = data.oci_core_vcn.dd_vcn[0].default_security_list_id
   depends_on                 = [module.vcn]
   freeform_tags              = var.tags
@@ -107,6 +117,7 @@ resource "oci_core_default_security_list" "dd_default" {
 }
 
 resource "oci_functions_application" "dd_function_app" {
+  count          = local.existing_function_app_id == null ? 1 : 0
   compartment_id = var.compartment_ocid
   display_name   = "dd-function-app"
   freeform_tags  = var.tags

--- a/datadog-integration/modules/regional-stacks/outputs.tf
+++ b/datadog-integration/modules/regional-stacks/outputs.tf
@@ -1,6 +1,6 @@
 output "output_ids" {
   value = {
     subnet       = local.subnet_id
-    function_app = oci_functions_application.dd_function_app.id
+    function_app = local.function_app_id
   }
 }

--- a/datadog-oci-orm/policy-setup/data.tf
+++ b/datadog-oci-orm/policy-setup/data.tf
@@ -14,6 +14,6 @@ data "oci_identity_domains_user" "user_in_domain" {
 }
 
 locals {
-  matching_domain = data.oci_identity_user.current_user.email == null ? [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null][0] : null
+  matching_domain = data.oci_identity_user.current_user.email == null ? [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.emails != null][0] : null
   email           = data.oci_identity_user.current_user.email != null ? data.oci_identity_user.current_user.email : data.oci_identity_domains_user.user_in_domain[local.matching_domain].emails[0].value
 }

--- a/datadog-oci-orm/policy-setup/data.tf
+++ b/datadog-oci-orm/policy-setup/data.tf
@@ -14,6 +14,6 @@ data "oci_identity_domains_user" "user_in_domain" {
 }
 
 locals {
-  matching_domain = data.oci_identity_user.current_user.email == null ? [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.emails != null][0] : null
+  matching_domain = data.oci_identity_user.current_user.email == null ? [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null][0] : null
   email           = data.oci_identity_user.current_user.email != null ? data.oci_identity_user.current_user.email : data.oci_identity_domains_user.user_in_domain[local.matching_domain].emails[0].value
 }

--- a/datadog-terraform-onboarding/data.tf
+++ b/datadog-terraform-onboarding/data.tf
@@ -39,3 +39,12 @@ data "oci_identity_domain" "domain" {
   domain_id = local.matching_domain_id
 }
 
+# Used when an explicit domain_id is provided so email can be inferred directly
+# from that domain rather than the all_domains-derived map, which only covers
+# domains in the tenancy root compartment.
+data "oci_identity_domains_user" "user_in_explicit_domain" {
+  count         = var.domain_id != null && var.domain_id != "" && (var.existing_user_id == null || var.existing_user_id == "") ? 1 : 0
+  idcs_endpoint = data.oci_identity_domain.domain.url
+  user_id       = var.current_user_ocid
+}
+

--- a/datadog-terraform-onboarding/data.tf
+++ b/datadog-terraform-onboarding/data.tf
@@ -43,7 +43,11 @@ data "oci_identity_domain" "domain" {
 # from that domain rather than the all_domains-derived map, which only covers
 # domains in the tenancy root compartment.
 data "oci_identity_domains_user" "user_in_explicit_domain" {
-  count         = var.domain_id != null && var.domain_id != "" && (var.existing_user_id == null || var.existing_user_id == "") ? 1 : 0
+  count = (
+    var.domain_id != null && var.domain_id != "" &&
+    (var.existing_user_id == null || var.existing_user_id == "") &&
+    (var.user_email == null || var.user_email == "")
+  ) ? 1 : 0
   idcs_endpoint = data.oci_identity_domain.domain.url
   user_id       = var.current_user_ocid
 }

--- a/datadog-terraform-onboarding/locals.tf
+++ b/datadog-terraform-onboarding/locals.tf
@@ -40,23 +40,20 @@ locals {
       # If a user and group are specified, find the associated domain
       var.existing_user_id != null && var.existing_user_id != "" ?
       (
-        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null][0] :
+        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null][0] :
         null
       ) :
-      # If no user or group is specified, find the domain associated with the current user
+      # If no user or group is specified, find the domain associated with the current user.
+      # Note: all_domains only lists domains in the tenancy root compartment. If the
+      # domain is in a child compartment, provide domain_id explicitly.
       (
-        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null][0] :
+        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null][0] :
         null
       )
     )
   )
-
-  matching_domain = [
-    for d in data.oci_identity_domains.all_domains.domains : d
-    if d.id == local.matching_domain_id
-  ][0]
 
   user_email = (
     # If the email is provided, use that
@@ -66,13 +63,17 @@ locals {
         var.existing_user_id != null && var.existing_user_id != "" ? (
           null
         ):
-          # If no user is specified, infer the email from the current logged in user
-          data.oci_identity_domains_user.user_in_domain[local.matching_domain_id].emails[0].value
+          # If no user is specified, infer the email from the current logged in user.
+          # When domain_id is explicitly provided, use the direct lookup so child-compartment
+          # domains (absent from the all_domains map) don't cause an invalid key error.
+          var.domain_id != null && var.domain_id != "" ?
+            data.oci_identity_domains_user.user_in_explicit_domain[0].emails[0].value :
+            data.oci_identity_domains_user.user_in_domain[local.matching_domain_id].emails[0].value
       )
   )
 
-  domain_display_name = local.matching_domain.display_name
-  idcs_endpoint       = local.matching_domain.url
+  domain_display_name = data.oci_identity_domain.domain.display_name
+  idcs_endpoint       = data.oci_identity_domain.domain.url
 
   actual_user_name  = (var.existing_user_id == null || var.existing_user_id == "") ? local.user_name : null
   actual_group_name = (var.existing_group_id == null || var.existing_group_id == "") ? local.user_group_name : null

--- a/datadog-terraform-onboarding/locals.tf
+++ b/datadog-terraform-onboarding/locals.tf
@@ -40,16 +40,16 @@ locals {
       # If a user and group are specified, find the associated domain
       var.existing_user_id != null && var.existing_user_id != "" ?
       (
-        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.id != null][0] :
+        length([for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.existing_user_in_domain : k if v.active != null][0] :
         null
       ) :
       # If no user or group is specified, find the domain associated with the current user.
       # Note: all_domains only lists domains in the tenancy root compartment. If the
       # domain is in a child compartment, provide domain_id explicitly.
       (
-        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null]) > 0 ?
-        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.id != null][0] :
+        length([for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null]) > 0 ?
+        [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.active != null][0] :
         null
       )
     )


### PR DESCRIPTION
## What

When a customer adds a custom function to `dd-function-app` and then destroys+reapplies the regional stack, the previous code would fail silently:
- OCI refuses to delete the Functions Application (still has unmanaged functions)
- The orphaned VCN's hardcoded `dns_label = "ddvcnmodule"` conflicts with the new VCN Terraform tries to create
- The regional stack apply job exits non-zero, but the parent stack's `null_resource` swallows the error and reports `SUCCESS`
- Result: `dd-logs-forwarder` and `dd-metrics-forwarder` are never created

## Why

The root cause is that `oci_functions_application.dd_function_app` was unconditional — Terraform always tried to create a new one, even when an active one already existed with the same display name, and always tried to create a new VCN with the same hardcoded DNS label.

## Fix

**`modules/regional-stacks/data.tf`**
- Added `data "oci_functions_applications" "existing_dd_function_app"` to detect an active `dd-function-app` in the compartment at plan time.
- Added a `check` block (`adopted_app_config`) that warns when the adopted app's `DD_SITE` or `API_KEY_SECRET_OCID` config diverges from the current stack variables (config cannot be updated automatically without OCI CLI or Terraform >= 1.7 dynamic imports).

**`modules/regional-stacks/locals.tf`**
- `existing_function_app_id`: frozen via `terraform_data` at first apply to avoid the idempotency trap (data source finds the app Terraform itself created on subsequent plans and would flip `count` back to 0).
- When `var.subnet_ocid` is explicitly provided, adoption is skipped so the operator's explicit subnet preference is honoured.
- `function_app_id`: `coalesce(adopted_id, created_id)` — works regardless of which path was taken.
- `create_network`: `false` when an orphaned app is adopted (the existing app already has a subnet).
- `subnet_id`: priority order — explicit OCID → adopted app's subnet → newly created subnet.

**`modules/regional-stacks/main.tf`**
- `terraform_data.adopted_function_app_id`: freezes the orphaned app OCID at first apply using `lifecycle { ignore_changes = [input] }`.
- `oci_functions_application.dd_function_app`: gains `count = local.existing_function_app_id == null ? 1 : 0`.
- Both `oci_functions_function` resources: use `local.function_app_id` instead of the direct resource reference.
- VCN, subnet, and default security list: counts changed from `var.subnet_ocid == "" ? 1 : 0` to `local.create_network ? 1 : 0`.

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| First-time deploy, no existing app | Creates app + VCN + functions ✓ | Same ✓ |
| Explicit `subnet_ocid` provided | Creates app, uses explicit subnet ✓ | Same ✓ |
| Orphaned app (failed destroy), no explicit subnet | Silent failure: duplicate VCN DNS conflict | Adopts app, skips VCN creation, creates functions ✓ |
| Orphaned app + explicit `subnet_ocid` | Silent failure | Skips adoption, creates new app in explicit subnet ✓ |
| Second apply after clean first apply | Idempotent ✓ | Same (frozen `terraform_data` stays null) ✓ |