### PR TITLE
[ECI-1615] Add IAM for HubManager to manage the events forwarding pipeline

### DIFF
--- a/datadog-integration/modules/auth/main.tf
+++ b/datadog-integration/modules/auth/main.tf
@@ -180,8 +180,22 @@ resource "oci_identity_domains_group" "dd_auth" {
   }
 }
 
+resource "oci_identity_tag_namespace" "datadog_managed" {
+  compartment_id = var.compartment_id
+  name           = "DatadogManaged"
+  description    = "[DO NOT REMOVE] Marker namespace for Datadog-managed resources. Removing this breaks the IAM grant scoping for the events rule."
+  freeform_tags  = var.tags
+  defined_tags   = var.defined_tags
+}
+
+resource "oci_identity_tag" "marker" {
+  tag_namespace_id = oci_identity_tag_namespace.datadog_managed.id
+  name             = "marker"
+  description      = "[DO NOT REMOVE] Applied to resources that the Datadog group is allowed to manage (e.g. the events rule). Removing this breaks the scoped IAM grant."
+}
+
 resource "oci_identity_policy" "dd_auth" {
-  depends_on     = [null_resource.user_group_variable_validation, oci_identity_domains_group.dd_auth]
+  depends_on     = [null_resource.user_group_variable_validation, oci_identity_domains_group.dd_auth, oci_identity_tag_namespace.datadog_managed]
   compartment_id = var.tenancy_id
   description    = "[DO NOT REMOVE] Policies required by Datadog User"
   name           = var.user_policy_name
@@ -194,7 +208,9 @@ resource "oci_identity_policy" "dd_auth" {
     "Allow group id ${local.dd_group_ocid} to manage buckets in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
     "Allow group id ${local.dd_group_ocid} to manage object-family in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
     "Allow group id ${local.dd_group_ocid} to use fn-invocation in compartment id ${var.compartment_id}",
-    "Endorse group id ${local.dd_group_ocid} to read objects in tenancy usage-report"
+    "Endorse group id ${local.dd_group_ocid} to read objects in tenancy usage-report",
+    "Allow group id ${local.dd_group_ocid} to manage cloudevents-rules in tenancy where any {request.permission = 'EVENTRULE_CREATE', target.resource.tag.DatadogManaged.marker = 'true'}",
+    "Allow group id ${local.dd_group_ocid} to manage streams in compartment id ${var.compartment_id} where any {request.permission = 'STREAM_CREATE', target.resource.tag.DatadogManaged.marker = 'true'}",
   ]
   freeform_tags = var.tags
   defined_tags  = var.defined_tags
@@ -229,7 +245,9 @@ resource "oci_identity_policy" "dynamic_group" {
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use fn-function in compartment id ${var.compartment_id}",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use fn-invocation in compartment id ${var.compartment_id}",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to read secret-bundles in compartment id ${var.compartment_id}",
-    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to manage object-family in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/"
+    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to manage object-family in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
+    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use stream-pull in compartment id ${var.compartment_id} where target.resource.tag.DatadogManaged.marker = 'true'",
+    "Allow any-user to use stream-push in compartment id ${var.compartment_id} where all {request.principal.type = 'eventrule', target.resource.tag.DatadogManaged.marker = 'true'}"
   ]
   freeform_tags = var.tags
   defined_tags  = var.defined_tags

--- a/datadog-terraform-onboarding/modules/auth/main.tf
+++ b/datadog-terraform-onboarding/modules/auth/main.tf
@@ -184,8 +184,22 @@ resource "oci_identity_domains_group" "dd_auth" {
   }
 }
 
+resource "oci_identity_tag_namespace" "datadog_managed" {
+  compartment_id = var.compartment_id
+  name           = "DatadogManaged"
+  description    = "[DO NOT REMOVE] Marker namespace for Datadog-managed resources. Removing this breaks the IAM grant scoping for the events rule."
+  freeform_tags  = var.tags
+  defined_tags   = var.defined_tags
+}
+
+resource "oci_identity_tag" "marker" {
+  tag_namespace_id = oci_identity_tag_namespace.datadog_managed.id
+  name             = "marker"
+  description      = "[DO NOT REMOVE] Applied to resources that the Datadog group is allowed to manage (e.g. the events rule). Removing this breaks the scoped IAM grant."
+}
+
 resource "oci_identity_policy" "dd_auth" {
-  depends_on     = [null_resource.user_group_variable_validation, oci_identity_domains_group.dd_auth]
+  depends_on     = [null_resource.user_group_variable_validation, oci_identity_domains_group.dd_auth, oci_identity_tag_namespace.datadog_managed]
   compartment_id = var.tenancy_id
   description    = "[DO NOT REMOVE] Policies required by Datadog User"
   name           = var.user_policy_name
@@ -198,7 +212,9 @@ resource "oci_identity_policy" "dd_auth" {
     "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage buckets in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
     "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage object-family in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
     "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to use fn-invocation in compartment id ${var.compartment_id}",
-    "Endorse group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to read objects in tenancy usage-report"
+    "Endorse group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to read objects in tenancy usage-report",
+    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage cloudevents-rules in tenancy where any {request.permission = 'EVENTRULE_CREATE', target.resource.tag.DatadogManaged.marker = 'true'}",
+    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage streams in compartment id ${var.compartment_id} where any {request.permission = 'STREAM_CREATE', target.resource.tag.DatadogManaged.marker = 'true'}",
   ]
   freeform_tags = var.tags
   defined_tags  = var.defined_tags
@@ -233,7 +249,9 @@ resource "oci_identity_policy" "dynamic_group" {
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use fn-function in compartment id ${var.compartment_id}",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use fn-invocation in compartment id ${var.compartment_id}",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to read secret-bundles in compartment id ${var.compartment_id}",
-    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to manage object-family in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/"
+    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to manage object-family in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
+    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use stream-pull in compartment id ${var.compartment_id} where target.resource.tag.DatadogManaged.marker = 'true'",
+    "Allow any-user to use stream-push in compartment id ${var.compartment_id} where all {request.principal.type = 'eventrule', target.resource.tag.DatadogManaged.marker = 'true'}"
   ]
   freeform_tags = var.tags
   defined_tags  = var.defined_tags


### PR DESCRIPTION
## What

Adds the IAM primitives the Datadog group (`dd-svc`) needs to stand up and tear down the OCI events forwarding pipeline out-of-band when a customer opts in / out via the Datadog UI. Applies the same set of changes to both stacks (`datadog-integration/` and `datadog-terraform-onboarding/`).

The pipeline resources themselves (function, stream, events rule, connector hub) are **not** created by this stack — Datadog creates them at runtime. This PR only adds the IAM so that flow works.

## Why

ECI-1615 / M1 of the OCI events RFC. The events flow requires:

- The Datadog group (acting as `dd-svc`) to create + delete the events rule, events stream, and forwarder function on opt-in / opt-out
- The SCH dynamic group to pull from the events stream and invoke the function
- OCI Events Service (acting as the `eventrule` service principal) to publish to the events stream when a rule fires

…all without granting the Datadog group the ability to touch resources it doesn't own.

## How resources are scoped

A `DatadogManaged.marker` defined tag (namespace + tag created in this PR) acts as the marker for Datadog-owned resources. Datadog tags every rule / stream it creates. Each grant uses a `where` clause that pairs **CREATE-via-`request.permission`** with **UPDATE/DELETE/READ-via-`target.resource.tag`** — this is the only way to enforce the tag because OCI's `target.resource.tag` doesn't evaluate against the request body on CREATE (the resource doesn't exist yet to read tags from).

## Changes (per auth module — applied identically to both)

### New resources

- `oci_identity_tag_namespace.datadog_managed` — `DatadogManaged` namespace in the Datadog compartment
- `oci_identity_tag.marker` — `marker` tag inside that namespace

### `oci_identity_policy.dd_auth` (Datadog group)

- `manage cloudevents-rules in tenancy where any { request.permission = 'EVENTRULE_CREATE', target.resource.tag.DatadogManaged.marker = 'true' }` — Datadog creates / deletes the events rule
- `manage streams in compartment where any { request.permission = 'STREAM_CREATE', target.resource.tag.DatadogManaged.marker = 'true' }` — Datadog creates / deletes the events stream (OCI streaming has no `target.stream.name` variable, so tag-based scoping is the only narrow option)

### `oci_identity_policy.dynamic_group` (runtime data path)

- `service_connector use stream-pull in compartment where target.resource.tag.DatadogManaged.marker = 'true'` — SCH consumes from the events stream
- `any-user use stream-push in compartment where all { request.principal.type = 'eventrule', target.resource.tag.DatadogManaged.marker = 'true' }` — OCI Events Service publishes to the events stream. `any-user` is required because `eventrule` is a service principal (no named group / dynamic-group represents it); the principal-type and target-tag conditions together restrict this to events-service publishes against Datadog-managed streams.

## Trade-off: CREATE is broader than UPDATE/DELETE

For both `cloudevents-rules` and `streams`, the `request.permission = '<X>_CREATE'` branch allows CREATE on *any* rule/stream in scope, not just ones being tagged. We can't enforce the tag on CREATE because OCI doesn't expose a `request.tag` variable, and `target.resource.tag` can't be evaluated when no target resource exists yet (per [OCI docs](https://docs.oracle.com/en-us/iaas/Content/Tagging/Tasks/managingaccesswithtags.htm)). Datadog code is the only consumer of this grant and always tags the resources it creates, so practical exposure is the same as tag-enforced create would be.

## Test plan

Validated end-to-end against `dddevintegration2` with the `dd-svc` user:

- **Event rule create with tag**: ✅ allowed (via `EVENTRULE_CREATE`)
- **Event rule create without tag**: ✅ allowed (same — Datadog won't actually do this)
- **Event rule update on tagged**: ✅ allowed
- **Event rule update on untagged**: ❌ `NotAuthorizedOrNotFound` (where-clause correctly scopes out)
- **Event rule delete on tagged / untagged**: ✅ / ❌
- **Stream create / update / delete**: same six-row matrix, all expected results
- **SCH stream-pull**: created two SCHes (source = tagged vs untagged stream), pushed a message to each:
  - Tagged-source SCH: `MessagesReadFromSource=1`, `MessagesWrittenToTarget=1`, errors=0
  - Untagged-source SCH: no metric datapoints emitted (the SCH service doesn't even attempt cycles when the dynamic-group identity is denied at the source)

## Backwards compatibility

Net diff is two new resources and four new policy statements per auth module — no changes to existing variables, schema, or resources. Stacks that don't actually use events still get these IAM additions but nothing exercises them.