### PR TITLE
ECI-1657: Provision IAM for OCI metrics backfill / DLQ buckets

### DIFF
--- a/datadog-integration/modules/auth/data.tf
+++ b/datadog-integration/modules/auth/data.tf
@@ -11,8 +11,8 @@ data "oci_identity_domains_groups" "existing_group" {
 
 # Get user by OCID with group memberships (when user OCID is provided and not empty)
 data "oci_identity_domains_users" "existing_user_with_groups" {
-  count        = var.existing_user_id != null && var.existing_user_id != "" ? 1 : 0
+  count         = var.existing_user_id != null && var.existing_user_id != "" ? 1 : 0
   idcs_endpoint = var.idcs_endpoint
-  user_filter  = "ocid eq \"${var.existing_user_id}\""
-  attributes   = "groups"
+  user_filter   = "ocid eq \"${var.existing_user_id}\""
+  attributes    = "groups"
 }

--- a/datadog-integration/modules/auth/main.tf
+++ b/datadog-integration/modules/auth/main.tf
@@ -190,7 +190,10 @@ resource "oci_identity_policy" "dd_auth" {
     "Allow group id ${local.dd_group_ocid} to read all-resources in tenancy",
     "Allow group id ${local.dd_group_ocid} to use tag-namespaces in tenancy",
     "Allow group id ${local.dd_group_ocid} to manage serviceconnectors in compartment id ${var.compartment_id}",
-    "Allow group id ${local.dd_group_ocid} to manage functions-family in compartment id ${var.compartment_id} where ANY {request.permission = 'FN_FUNCTION_UPDATE', request.permission = 'FN_FUNCTION_LIST', request.permission = 'FN_APP_LIST'}",
+    "Allow group id ${local.dd_group_ocid} to manage functions-family in compartment id ${var.compartment_id}",
+    "Allow group id ${local.dd_group_ocid} to manage buckets in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
+    "Allow group id ${local.dd_group_ocid} to manage object-family in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
+    "Allow group id ${local.dd_group_ocid} to use fn-invocation in compartment id ${var.compartment_id}",
     "Endorse group id ${local.dd_group_ocid} to read objects in tenancy usage-report"
   ]
   freeform_tags = var.tags
@@ -218,14 +221,15 @@ resource "oci_identity_domains_dynamic_resource_group" "forwarding_function" {
 resource "oci_identity_policy" "dynamic_group" {
   depends_on     = [null_resource.user_group_variable_validation, oci_identity_domains_dynamic_resource_group.service_connector]
   compartment_id = var.tenancy_id
-  description    = "[DO NOT REMOVE] Policy to have any connector hub read from eligible sources and write to a target function"
+  description    = "[DO NOT REMOVE] Policy for connector hubs and forwarding functions"
   name           = var.dg_policy_name
   statements = [
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to read log-content in tenancy",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to read metrics in tenancy",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use fn-function in compartment id ${var.compartment_id}",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use fn-invocation in compartment id ${var.compartment_id}",
-    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to read secret-bundles in compartment id ${var.compartment_id}"
+    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to read secret-bundles in compartment id ${var.compartment_id}",
+    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to manage object-family in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/"
   ]
   freeform_tags = var.tags
   defined_tags  = var.defined_tags

--- a/datadog-terraform-onboarding/modules/auth/data.tf
+++ b/datadog-terraform-onboarding/modules/auth/data.tf
@@ -11,8 +11,8 @@ data "oci_identity_domains_groups" "existing_group" {
 
 # Get user by OCID with group memberships (when user OCID is provided and not empty)
 data "oci_identity_domains_users" "existing_user_with_groups" {
-  count        = var.existing_user_id != null && var.existing_user_id != "" ? 1 : 0
+  count         = var.existing_user_id != null && var.existing_user_id != "" ? 1 : 0
   idcs_endpoint = var.idcs_endpoint
-  user_filter  = "ocid eq \"${var.existing_user_id}\""
-  attributes   = "groups"
+  user_filter   = "ocid eq \"${var.existing_user_id}\""
+  attributes    = "groups"
 }

--- a/datadog-terraform-onboarding/modules/auth/main.tf
+++ b/datadog-terraform-onboarding/modules/auth/main.tf
@@ -194,7 +194,10 @@ resource "oci_identity_policy" "dd_auth" {
     "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to read all-resources in tenancy",
     "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to use tag-namespaces in tenancy",
     "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage serviceconnectors in compartment id ${var.compartment_id}",
-    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage functions-family in compartment id ${var.compartment_id} where ANY {request.permission = 'FN_FUNCTION_UPDATE', request.permission = 'FN_FUNCTION_LIST', request.permission = 'FN_APP_LIST'}",
+    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage functions-family in compartment id ${var.compartment_id}",
+    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage buckets in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
+    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage object-family in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
+    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to use fn-invocation in compartment id ${var.compartment_id}",
     "Endorse group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to read objects in tenancy usage-report"
   ]
   freeform_tags = var.tags
@@ -222,14 +225,15 @@ resource "oci_identity_domains_dynamic_resource_group" "forwarding_function" {
 resource "oci_identity_policy" "dynamic_group" {
   depends_on     = [null_resource.user_group_variable_validation, oci_identity_domains_dynamic_resource_group.service_connector]
   compartment_id = var.tenancy_id
-  description    = "[DO NOT REMOVE] Policy to have any connector hub read from eligible sources and write to a target function"
+  description    = "[DO NOT REMOVE] Policy for connector hubs and forwarding functions"
   name           = var.dg_policy_name
   statements = [
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to read log-content in tenancy",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to read metrics in tenancy",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use fn-function in compartment id ${var.compartment_id}",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use fn-invocation in compartment id ${var.compartment_id}",
-    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to read secret-bundles in compartment id ${var.compartment_id}"
+    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to read secret-bundles in compartment id ${var.compartment_id}",
+    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to manage object-family in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/"
   ]
   freeform_tags = var.tags
   defined_tags  = var.defined_tags


### PR DESCRIPTION
## Summary

This change extends the Datadog integration **IAM policies** in `datadog-integration` and `datadog-terraform-onboarding` so the Datadog operator group and forwarding functions can **create and manage Object Storage backfill (DLQ) resources** for metrics in the customer Datadog compartment, without ad-hoc customer policy edits.

## What changed

### `dd-svc-policy` (`oci_identity_policy.dd_auth`)

- Replaced the narrow **`manage functions-family`** statement (limited to a small set of function permissions) with **full `manage functions-family`** in the Datadog compartment so hub automation can create and manage Functions applications and functions as needed for backfill workflows.
- Added **`manage buckets`** in the Datadog compartment **where `target.bucket.name=/dd-*/`**, so operators can create and administer buckets whose names match the `dd-*` prefix (for example `dd-metrics-backfill`).
- Added **`manage object-family`** with the **same bucket name condition**, so operators can manage **objects**, **lifecycle**, and **retention** rules on those buckets (for example a 168-hour TTL).
- Added **`use fn-invocation`** in the Datadog compartment so the operator group can **invoke** functions (for example triggering a metrics replay job).

### `dd-dynamic-group-policy` (`oci_identity_policy.dynamic_group`)

- Added **`manage object-family`** for **`dd-dynamic-group-functions`** (the forwarding functions dynamic group) **where `target.bucket.name=/dd-*/`**, so metrics forwarders using **resource principal** can **write** batched payloads to the DLQ bucket and **read / delete** objects during replay.

### Other

- Minor **Terraform formatting** alignment in `data.tf` (both modules).

## What this enables

- **Hub-managed provisioning** of `dd-*` backfill buckets and related object storage configuration in the customer account, aligned with the metrics forwarder bucket naming (`dd-metrics-backfill` in application code).
- **Operator-driven backfill** without asking the customer to hand-edit IAM for each new bucket or region, once the parent stack apply has run.
- **Forwarding functions** can persist metrics batches to Object Storage and drain them on replay under the same naming convention.

## Testing

The author **tested these policy shapes in OCI** and confirmed they allow **creating and managing** the Object Storage resources needed for **metrics backfill** in the target account (bucket create/update, object lifecycle path, and function invocation as required for the workflow).

---

**Ticket:** ECI-1657

Made with [Cursor](https://cursor.com)