### PR TITLE
feat(auth): scope bucket IAM to DatadogManaged.marker tag

### DIFF
--- a/datadog-integration/modules/auth/main.tf
+++ b/datadog-integration/modules/auth/main.tf
@@ -205,8 +205,8 @@ resource "oci_identity_policy" "dd_auth" {
     "Allow group id ${local.dd_group_ocid} to use tag-namespaces in tenancy",
     "Allow group id ${local.dd_group_ocid} to manage serviceconnectors in compartment id ${var.compartment_id}",
     "Allow group id ${local.dd_group_ocid} to manage functions-family in compartment id ${var.compartment_id}",
-    "Allow group id ${local.dd_group_ocid} to manage buckets in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
-    "Allow group id ${local.dd_group_ocid} to manage object-family in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
+    "Allow group id ${local.dd_group_ocid} to manage buckets in compartment id ${var.compartment_id} where any {request.permission = 'BUCKET_CREATE', target.resource.tag.DatadogManaged.marker = 'true'}",
+    "Allow group id ${local.dd_group_ocid} to manage object-family in compartment id ${var.compartment_id} where target.resource.tag.DatadogManaged.marker = 'true'",
     "Allow group id ${local.dd_group_ocid} to use fn-invocation in compartment id ${var.compartment_id}",
     "Endorse group id ${local.dd_group_ocid} to read objects in tenancy usage-report",
     "Allow group id ${local.dd_group_ocid} to manage cloudevents-rules in tenancy where any {request.permission = 'EVENTRULE_CREATE', target.resource.tag.DatadogManaged.marker = 'true'}",
@@ -245,7 +245,7 @@ resource "oci_identity_policy" "dynamic_group" {
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use fn-function in compartment id ${var.compartment_id}",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use fn-invocation in compartment id ${var.compartment_id}",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to read secret-bundles in compartment id ${var.compartment_id}",
-    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to manage object-family in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
+    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to manage object-family in compartment id ${var.compartment_id} where target.resource.tag.DatadogManaged.marker = 'true'",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use stream-pull in compartment id ${var.compartment_id} where target.resource.tag.DatadogManaged.marker = 'true'",
     "Allow any-user to use stream-push in compartment id ${var.compartment_id} where all {request.principal.type = 'eventrule', target.resource.tag.DatadogManaged.marker = 'true'}"
   ]

--- a/datadog-terraform-onboarding/modules/auth/main.tf
+++ b/datadog-terraform-onboarding/modules/auth/main.tf
@@ -209,8 +209,8 @@ resource "oci_identity_policy" "dd_auth" {
     "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to use tag-namespaces in tenancy",
     "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage serviceconnectors in compartment id ${var.compartment_id}",
     "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage functions-family in compartment id ${var.compartment_id}",
-    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage buckets in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
-    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage object-family in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
+    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage buckets in compartment id ${var.compartment_id} where any {request.permission = 'BUCKET_CREATE', target.resource.tag.DatadogManaged.marker = 'true'}",
+    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage object-family in compartment id ${var.compartment_id} where target.resource.tag.DatadogManaged.marker = 'true'",
     "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to use fn-invocation in compartment id ${var.compartment_id}",
     "Endorse group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to read objects in tenancy usage-report",
     "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage cloudevents-rules in tenancy where any {request.permission = 'EVENTRULE_CREATE', target.resource.tag.DatadogManaged.marker = 'true'}",
@@ -249,7 +249,7 @@ resource "oci_identity_policy" "dynamic_group" {
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use fn-function in compartment id ${var.compartment_id}",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use fn-invocation in compartment id ${var.compartment_id}",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to read secret-bundles in compartment id ${var.compartment_id}",
-    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to manage object-family in compartment id ${var.compartment_id} where target.bucket.name=/dd-*/",
+    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to manage object-family in compartment id ${var.compartment_id} where target.resource.tag.DatadogManaged.marker = 'true'",
     "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use stream-pull in compartment id ${var.compartment_id} where target.resource.tag.DatadogManaged.marker = 'true'",
     "Allow any-user to use stream-push in compartment id ${var.compartment_id} where all {request.principal.type = 'eventrule', target.resource.tag.DatadogManaged.marker = 'true'}"
   ]


### PR DESCRIPTION
## Summary

Scopes Object Storage bucket and object-family IAM for the Datadog group and forwarding-function dynamic group using the existing `DatadogManaged.marker` defined tag, consistent with cloudevents-rules and streams policies.

## What changed

- **`dd_auth` policy:** Replaces `target.bucket.name=/dd-*/` with:
  - `manage buckets` → `any {request.permission = 'BUCKET_CREATE', target.resource.tag.DatadogManaged.marker = 'true'}`
  - `manage object-family` → `target.resource.tag.DatadogManaged.marker = 'true'`
- **`dynamic_group` policy:** Forwarding functions `manage object-family` uses the same marker tag condition.
- Applied in both `datadog-integration` and `datadog-terraform-onboarding` auth modules.

## Why

Aligns backfill/DLQ bucket access with the same tag-based scoping model as events and streams, instead of a broad `dd-*` name prefix.

## Testing

- [ ] Apply stack in test tenancy and confirm bucket create/read/write works when buckets are created with `DatadogManaged.marker = true`
- [ ] Confirm buckets without the marker are not accessible under these statements
- [ ] Re-apply or update IAM policies if upgrading an existing integration (policy statement change)

## Follow-up

Ensure any buckets the stack creates (e.g. metrics DLQ/backfill) are tagged with `DatadogManaged.marker = true` at create time if not already.


Made with [Cursor](https://cursor.com)