### PR TITLE
[SCMGMT-609] chore: add CODEOWNERS with emerging-cloud-integrations as default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @DataDog/emerging-cloud-integrations


### PR DESCRIPTION
## Summary
- Created `.github/CODEOWNERS` with `@DataDog/emerging-cloud-integrations` as the catch-all default owner
- Team has push access and 3/5 top contributors are team members
- No existing path-specific rules to preserve

> Note: Team currently has push-level access. If this team is not the right owner, please let us know and we can update accordingly.

JIRA: SCMGMT-609