### PR TITLE
ECI-1542: Add logs_only onboarding variable

### DIFF
--- a/datadog-integration/main.tf
+++ b/datadog-integration/main.tf
@@ -265,6 +265,7 @@ module "integration" {
   subscribed_regions              = tolist(local.final_regions_for_stacks)
   datadog_resource_compartment_id = module.compartment.id
   logs_enabled                    = var.logs_enabled
+  logs_only                       = var.logs_only
   defined_tags                    = local.defined_tags
 }
 

--- a/datadog-integration/modules/integration/locals.tf
+++ b/datadog-integration/modules/integration/locals.tf
@@ -1,27 +1,34 @@
 locals {
 
   config_version = 2
+  base_attributes = {
+    home_region : var.home_region
+    user_ocid : var.user_ocid
+    config_version : local.config_version
+    auth_credentials : {
+      private_key : var.private_key
+    },
+    regions_config : {
+      available : var.subscribed_regions
+    }
+    dd_compartment_id : var.datadog_resource_compartment_id
+    dd_stack_id : try(data.external.stack_info.result.stack_id, "")
+    logs_config : {
+      Enabled : var.logs_enabled
+    }
+    defined_tags : [for k, v in var.defined_tags : "${k}:${v}"]
+  }
+  logs_only_attributes = { for k, v in {
+    resource_collection_enabled : false
+    metrics_config : {
+      enabled : false
+    }
+  } : k => v if var.logs_only }
   json_object = {
     data : {
       type : "oci_tenancy",
       id : var.tenancy_ocid,
-      attributes : {
-        home_region : var.home_region
-        user_ocid : var.user_ocid
-        config_version : local.config_version
-        auth_credentials : {
-          private_key : var.private_key
-        },
-        regions_config : {
-          available : var.subscribed_regions
-        }
-        dd_compartment_id : var.datadog_resource_compartment_id
-        dd_stack_id : try(data.external.stack_info.result.stack_id, "")
-        logs_config : {
-          Enabled : var.logs_enabled
-        }
-        defined_tags : [for k, v in var.defined_tags : "${k}:${v}"]
-      }
+      attributes : merge(local.base_attributes, local.logs_only_attributes)
     }
   }
   request_data = jsonencode(local.json_object)

--- a/datadog-integration/modules/integration/variables.tf
+++ b/datadog-integration/modules/integration/variables.tf
@@ -55,6 +55,12 @@ variable "logs_enabled" {
   default     = false
 }
 
+variable "logs_only" {
+  type        = bool
+  description = "If true, disable metrics and resource collection in the integration request body."
+  default     = false
+}
+
 variable "defined_tags" {
   type        = map(string)
   description = "OCI defined tags applied to resources (namespace.key -> value). Sent to Datadog for integration config."

--- a/datadog-integration/schema.yaml
+++ b/datadog-integration/schema.yaml
@@ -121,7 +121,7 @@ variables:
     title: Logs Only
     type: boolean
     description: |
-      If true, onboard the integration for logs only. Metrics and resource collection will be disabled in the Datadog integration, but can be re-enabled in the Datadog Tile UI
+      If true, the integration will be created with only logs enabled. Metrics and resource collection will be disabled, but can be re-enabled in the Datadog Tile UI.
     required: false
     default: false
 

--- a/datadog-integration/schema.yaml
+++ b/datadog-integration/schema.yaml
@@ -12,6 +12,7 @@ variableGroups:
       - ${region}
       - ${compartment_ocid}
       - ${current_user_ocid}
+      - ${logs_only}
     visible: false
   - title: "Datadog Environment"
     variables:
@@ -113,6 +114,14 @@ variables:
     type: string
     description: |
       Indicates if logs should be enabled/disabled
+    required: false
+    default: false
+
+  logs_only:
+    title: Logs Only
+    type: boolean
+    description: |
+      If true, onboard the integration for logs only. Metrics and resource collection will be disabled in the Datadog integration.
     required: false
     default: false
 

--- a/datadog-integration/schema.yaml
+++ b/datadog-integration/schema.yaml
@@ -121,7 +121,7 @@ variables:
     title: Logs Only
     type: boolean
     description: |
-      If true, onboard the integration for logs only. Metrics and resource collection will be disabled in the Datadog integration.
+      If true, onboard the integration for logs only. Metrics and resource collection will be disabled in the Datadog integration, but can be re-enabled in the Datadog Tile UI
     required: false
     default: false
 

--- a/datadog-integration/variables.tf
+++ b/datadog-integration/variables.tf
@@ -79,7 +79,7 @@ variable "logs_enabled" {
 
 variable "logs_only" {
   type        = bool
-  description = "If true, onboard the integration for logs only. Metrics and resource collection will be disabled in the Datadog integration, but can be re-enabled in the Datadog Tile UI"
+  description = "If true, the integration will be created with only logs enabled. Metrics and resource collection will be disabled, but can be re-enabled in the Datadog Tile UI."
   default     = false
 }
 

--- a/datadog-integration/variables.tf
+++ b/datadog-integration/variables.tf
@@ -77,6 +77,12 @@ variable "logs_enabled" {
   default     = false
 }
 
+variable "logs_only" {
+  type        = bool
+  description = "If true, onboard the integration for logs only. Metrics and resource collection will be disabled in the Datadog integration."
+  default     = false
+}
+
 variable "domain_id" {
   type        = string
   description = "The OCID of the Identity Domain to use for the Datadog QuickStart stack"

--- a/datadog-integration/variables.tf
+++ b/datadog-integration/variables.tf
@@ -79,7 +79,7 @@ variable "logs_enabled" {
 
 variable "logs_only" {
   type        = bool
-  description = "If true, onboard the integration for logs only. Metrics and resource collection will be disabled in the Datadog integration."
+  description = "If true, onboard the integration for logs only. Metrics and resource collection will be disabled in the Datadog integration, but can be re-enabled in the Datadog Tile UI"
   default     = false
 }
 

--- a/datadog-terraform-onboarding/main.tf
+++ b/datadog-terraform-onboarding/main.tf
@@ -242,6 +242,7 @@ module "integration" {
   subscribed_regions              = tolist(local.final_regions_for_stacks)
   datadog_resource_compartment_id = module.compartment.id
   logs_enabled                    = var.logs_enabled
+  logs_only                       = var.logs_only
   defined_tags                    = local.defined_tags
 }
 

--- a/datadog-terraform-onboarding/modules/integration/locals.tf
+++ b/datadog-terraform-onboarding/modules/integration/locals.tf
@@ -1,25 +1,32 @@
 locals {
   config_version = 3
+  base_attributes = {
+    home_region : var.home_region
+    user_ocid : var.user_ocid
+    config_version : local.config_version
+    auth_credentials : {
+      private_key : var.private_key
+    },
+    regions_config : {
+      available : var.subscribed_regions
+    }
+    dd_compartment_id : var.datadog_resource_compartment_id
+    logs_config : {
+      Enabled = var.logs_enabled
+    }
+    defined_tags : [for k, v in var.defined_tags : "${k}:${v}"]
+  }
+  logs_only_attributes = { for k, v in {
+    resource_collection_enabled : false
+    metrics_config : {
+      enabled : false
+    }
+  } : k => v if var.logs_only }
   json_object = {
     data : {
       type : "oci_tenancy",
       id : var.tenancy_ocid,
-      attributes : {
-        home_region : var.home_region
-        user_ocid : var.user_ocid
-        config_version : local.config_version
-        auth_credentials : {
-          private_key : var.private_key
-        },
-        regions_config : {
-          available : var.subscribed_regions
-        }
-        dd_compartment_id : var.datadog_resource_compartment_id
-        logs_config : {
-          Enabled = var.logs_enabled
-        }
-        defined_tags : [for k, v in var.defined_tags : "${k}:${v}"]
-      }
+      attributes : merge(local.base_attributes, local.logs_only_attributes)
     }
   }
   request_data = jsonencode(local.json_object)

--- a/datadog-terraform-onboarding/modules/integration/variables.tf
+++ b/datadog-terraform-onboarding/modules/integration/variables.tf
@@ -55,6 +55,12 @@ variable "logs_enabled" {
   default     = false
 }
 
+variable "logs_only" {
+  type        = bool
+  description = "If true, disable metrics and resource collection in the integration request body."
+  default     = false
+}
+
 variable "defined_tags" {
   type        = map(string)
   description = "OCI defined tags applied to resources (namespace.key -> value). Sent to Datadog for integration config."

--- a/datadog-terraform-onboarding/variables.tf
+++ b/datadog-terraform-onboarding/variables.tf
@@ -72,7 +72,7 @@ variable "logs_enabled" {
 
 variable "logs_only" {
   type        = bool
-  description = "If true, onboard the integration for logs only. Metrics and resource collection will be disabled in the Datadog integration, but can be re-enabled in the Datadog Tile UI"
+  description = "If true, the integration will be created with only logs enabled. Metrics and resource collection will be disabled, but can be re-enabled in the Datadog Tile UI."
   default     = false
 }
 

--- a/datadog-terraform-onboarding/variables.tf
+++ b/datadog-terraform-onboarding/variables.tf
@@ -72,7 +72,7 @@ variable "logs_enabled" {
 
 variable "logs_only" {
   type        = bool
-  description = "If true, onboard the integration for logs only. Metrics and resource collection will be disabled in the Datadog integration."
+  description = "If true, onboard the integration for logs only. Metrics and resource collection will be disabled in the Datadog integration, but can be re-enabled in the Datadog Tile UI"
   default     = false
 }
 

--- a/datadog-terraform-onboarding/variables.tf
+++ b/datadog-terraform-onboarding/variables.tf
@@ -70,6 +70,12 @@ variable "logs_enabled" {
   default     = true
 }
 
+variable "logs_only" {
+  type        = bool
+  description = "If true, onboard the integration for logs only. Metrics and resource collection will be disabled in the Datadog integration."
+  default     = false
+}
+
 variable "domain_id" {
   type        = string
   description = "The OCID of the Identity Domain to use for the Datadog QuickStart stack"


### PR DESCRIPTION
For reference: [Datadog Logs Only Onboarding Flow
](https://app.datadoghq.com/signup/setup/logs/cloud-provider)
## What
Adds a `logs_only` bool variable to the `datadog-integration` (OCI ORM Stack) and `datadog-terraform-onboarding` (advanced Terraform) modules. When `logs_only=true`, the create request to the Datadog OCI integration API sends `resource_collection_enabled=false` and `metrics_config.enabled=false`, so the tenancy is onboarded for logs collection only. Updates made to these fields from stack requests are ignored, similar to how logs behave.

## Why
[ECI-1542](https://datadoghq.atlassian.net/browse/ECI-1542) — Support a logs-only onboarding flow for OCI from the Datadog UI (`/signup/setup/logs/cloud-provider`). The signup UI will deep-link into OCI Resource Manager with `logs_only:true`, and the stack must propagate that into the integration request so the org isn't billed for metrics/resources it didn't ask for. The companion dd-source PR makes the API ignore subsequent metrics/resource updates from these Terraform clients so users can later enable them in the UI without the stack reverting them.

## Testing
- `terraform validate` passes for both `datadog-integration` and `datadog-terraform-onboarding`.
- Inspected the rendered `request_data` JSON: with `logs_only=false` the payload is unchanged (no `resource_collection_enabled` or `metrics_config` keys); with `logs_only=true` both fields are present with disabled values.
- Default of `false` preserves existing behavior for current users.

[ECI-1542]: https://datadoghq.atlassian.net/browse/ECI-1542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ