### PR TITLE
fix(datadog-integration): expose logs_only for zipUrlVariables

### DIFF
--- a/datadog-integration/modules/integration/variables.tf
+++ b/datadog-integration/modules/integration/variables.tf
@@ -57,7 +57,7 @@ variable "logs_enabled" {
 
 variable "logs_only" {
   type        = bool
-  description = "Indicates if the integration should be created with metric and resource collection disabled"
+  description = "Indicates if the integration should be created with metric and resource collection disabled, but available"
   default     = false
 }
 

--- a/datadog-integration/modules/integration/variables.tf
+++ b/datadog-integration/modules/integration/variables.tf
@@ -57,7 +57,7 @@ variable "logs_enabled" {
 
 variable "logs_only" {
   type        = bool
-  description = "If true, disable metrics and resource collection in the integration request body."
+  description = "Indicates if the integration should be created with metric and resource collection disabled"
   default     = false
 }
 

--- a/datadog-integration/schema.yaml
+++ b/datadog-integration/schema.yaml
@@ -12,7 +12,6 @@ variableGroups:
       - ${region}
       - ${compartment_ocid}
       - ${current_user_ocid}
-      - ${logs_only}
     visible: false
   - title: "Datadog Environment"
     variables:
@@ -20,6 +19,7 @@ variableGroups:
       - ${datadog_api_key}
       - ${datadog_site}
       - ${logs_enabled}
+      - ${logs_only}
   - title: "(Optional) Choose specific subnet(s)"
     variables:
       - ${choose_subnet}
@@ -121,7 +121,7 @@ variables:
     title: Logs Only
     type: boolean
     description: |
-      If true, the integration will be created with only logs enabled. Metrics and resource collection will be disabled, but can be re-enabled in the Datadog Tile UI.
+      Indicates if the integration should be created with metric and resource collection disabled
     required: false
     default: false
 

--- a/datadog-integration/schema.yaml
+++ b/datadog-integration/schema.yaml
@@ -121,7 +121,7 @@ variables:
     title: Logs Only
     type: boolean
     description: |
-      Indicates if the integration should be created with metric and resource collection disabled
+      Indicates if the integration should be created with metric and resource collection disabled, but available
     required: false
     default: false
 

--- a/datadog-integration/variables.tf
+++ b/datadog-integration/variables.tf
@@ -79,7 +79,7 @@ variable "logs_enabled" {
 
 variable "logs_only" {
   type        = bool
-  description = "If true, the integration will be created with only logs enabled. Metrics and resource collection will be disabled, but can be re-enabled in the Datadog Tile UI."
+  description = "Indicates if the integration should be created with metric and resource collection disabled"
   default     = false
 }
 

--- a/datadog-integration/variables.tf
+++ b/datadog-integration/variables.tf
@@ -79,7 +79,7 @@ variable "logs_enabled" {
 
 variable "logs_only" {
   type        = bool
-  description = "Indicates if the integration should be created with metric and resource collection disabled"
+  description = "Indicates if the integration should be created with metric and resource collection disabled, but available"
   default     = false
 }
 

--- a/datadog-terraform-onboarding/modules/integration/variables.tf
+++ b/datadog-terraform-onboarding/modules/integration/variables.tf
@@ -57,7 +57,7 @@ variable "logs_enabled" {
 
 variable "logs_only" {
   type        = bool
-  description = "Indicates if the integration should be created with metric and resource collection disabled"
+  description = "Indicates if the integration should be created with metric and resource collection disabled, but available"
   default     = false
 }
 

--- a/datadog-terraform-onboarding/modules/integration/variables.tf
+++ b/datadog-terraform-onboarding/modules/integration/variables.tf
@@ -57,7 +57,7 @@ variable "logs_enabled" {
 
 variable "logs_only" {
   type        = bool
-  description = "If true, disable metrics and resource collection in the integration request body."
+  description = "Indicates if the integration should be created with metric and resource collection disabled"
   default     = false
 }
 

--- a/datadog-terraform-onboarding/variables.tf
+++ b/datadog-terraform-onboarding/variables.tf
@@ -72,7 +72,7 @@ variable "logs_enabled" {
 
 variable "logs_only" {
   type        = bool
-  description = "Indicates if the integration should be created with metric and resource collection disabled"
+  description = "Indicates if the integration should be created with metric and resource collection disabled, but available"
   default     = false
 }
 

--- a/datadog-terraform-onboarding/variables.tf
+++ b/datadog-terraform-onboarding/variables.tf
@@ -72,7 +72,7 @@ variable "logs_enabled" {
 
 variable "logs_only" {
   type        = bool
-  description = "If true, the integration will be created with only logs enabled. Metrics and resource collection will be disabled, but can be re-enabled in the Datadog Tile UI."
+  description = "Indicates if the integration should be created with metric and resource collection disabled"
   default     = false
 }
 


### PR DESCRIPTION
## Summary
- Move `logs_only` from the hidden Tenancy `variableGroup` to **Datadog Environment** so OCI Resource Manager keeps it when passed via `zipUrlVariables` (hidden groups were dropping it).
- Show **Logs Only** in the stack UI (visible group, checkbox).
- Align `logs_only` descriptions: integration is created with metric and resource collection **disabled, but available** (forwarding infra is still provisioned; collection can be re-enabled in the Datadog tile).

## Why
Stacks created from the logs onboarding URL included `logs_only: true` in `zipUrlVariables`, but `oci resource-manager stack get` showed the key missing while other variables (e.g. `logs_enabled`) were present. Root cause: `logs_only` was only listed under `visible: false` Tenancy.

## Test plan
- [ ] Cut/publish new `datadog-integration.zip` release after merge
- [ ] Create stack from logs onboarding URL with `logs_only: true` in `zipUrlVariables`
- [ ] Confirm `data.variables` includes `"logs_only": true` via `oci resource-manager stack get --region <home>`
- [ ] Run apply and verify Datadog integration payload disables metrics/resource collection