### PR TITLE
fix(events-forwarder): decode SCH streaming base64 envelopes, simplify Decode

### DIFF
--- a/datadog-functions/events-forwarder/internal/formatter/formatter.go
+++ b/datadog-functions/events-forwarder/internal/formatter/formatter.go
@@ -34,6 +34,7 @@ func Decode(in io.Reader) ([]json.RawMessage, error) {
 	}
 	out := make([]json.RawMessage, 0, len(msgs))
 	for i, sm := range msgs {
+		// OCI Streaming encodes message values as standard RFC 4648 base64 (with padding).
 		decoded, err := base64.StdEncoding.DecodeString(sm.Value)
 		if err != nil {
 			return nil, fmt.Errorf("streaming message %d: failed to base64-decode value: %w", i, err)
@@ -43,6 +44,9 @@ func Decode(in io.Reader) ([]json.RawMessage, error) {
 		}
 		if decoded[0] != '{' {
 			return nil, fmt.Errorf("streaming message %d: decoded value is not a JSON object", i)
+		}
+		if !json.Valid(decoded) {
+			return nil, fmt.Errorf("streaming message %d: decoded value is not valid JSON", i)
 		}
 		out = append(out, json.RawMessage(decoded))
 	}

--- a/datadog-functions/events-forwarder/internal/formatter/formatter.go
+++ b/datadog-functions/events-forwarder/internal/formatter/formatter.go
@@ -41,8 +41,8 @@ func Decode(in io.Reader) ([]json.RawMessage, error) {
 		if len(decoded) == 0 {
 			return nil, fmt.Errorf("streaming message %d: decoded value is empty", i)
 		}
-		if !json.Valid(decoded) {
-			return nil, fmt.Errorf("streaming message %d: decoded value is not valid JSON", i)
+		if decoded[0] != '{' {
+			return nil, fmt.Errorf("streaming message %d: decoded value is not a JSON object", i)
 		}
 		out = append(out, json.RawMessage(decoded))
 	}

--- a/datadog-functions/events-forwarder/internal/formatter/formatter.go
+++ b/datadog-functions/events-forwarder/internal/formatter/formatter.go
@@ -38,6 +38,12 @@ func Decode(in io.Reader) ([]json.RawMessage, error) {
 		if err != nil {
 			return nil, fmt.Errorf("streaming message %d: failed to base64-decode value: %w", i, err)
 		}
+		if len(decoded) == 0 {
+			return nil, fmt.Errorf("streaming message %d: decoded value is empty", i)
+		}
+		if !json.Valid(decoded) {
+			return nil, fmt.Errorf("streaming message %d: decoded value is not valid JSON", i)
+		}
 		out = append(out, json.RawMessage(decoded))
 	}
 	return out, nil

--- a/datadog-functions/events-forwarder/internal/formatter/formatter.go
+++ b/datadog-functions/events-forwarder/internal/formatter/formatter.go
@@ -4,10 +4,52 @@
 package formatter
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 )
+
+// streamingMessage is the per-message envelope that Service Connector Hub
+// delivers to Functions when the source is OCI Streaming. The actual OCI
+// Cloud Event JSON is base64-encoded in the Value field.
+type streamingMessage struct {
+	Value string `json:"value"`
+}
+
+// isStreamingFormat reports whether msgs looks like an SCH streaming batch:
+// each element has a "value" field but no "eventType" field (which is
+// mandatory in every OCI Cloud Event envelope).
+func isStreamingFormat(msgs []json.RawMessage) bool {
+	if len(msgs) == 0 {
+		return false
+	}
+	var first map[string]json.RawMessage
+	if err := json.Unmarshal(msgs[0], &first); err != nil {
+		return false
+	}
+	_, hasValue := first["value"]
+	_, hasEventType := first["eventType"]
+	return hasValue && !hasEventType
+}
+
+// decodeStreamingMessages base64-decodes the "value" field of each SCH
+// streaming message and returns the inner OCI Cloud Event JSON payloads.
+func decodeStreamingMessages(msgs []json.RawMessage) ([]json.RawMessage, error) {
+	out := make([]json.RawMessage, 0, len(msgs))
+	for i, msg := range msgs {
+		var sm streamingMessage
+		if err := json.Unmarshal(msg, &sm); err != nil {
+			return nil, fmt.Errorf("streaming message %d: failed to unmarshal: %w", i, err)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(sm.Value)
+		if err != nil {
+			return nil, fmt.Errorf("streaming message %d: failed to base64-decode value: %w", i, err)
+		}
+		out = append(out, json.RawMessage(decoded))
+	}
+	return out, nil
+}
 
 // Intake limits enforced by cloudplatform-intake/api/v2/cloudchanges.
 const (
@@ -15,9 +57,14 @@ const (
 	MaxBatchCount = 65536
 )
 
-// Decode accepts either a single OCI CloudEvents envelope or an array of
-// envelopes. Events are returned as RawMessage so downstream chunking can
-// operate on encoded sizes without re-encoding each element.
+// Decode accepts:
+//  1. A single OCI CloudEvents envelope
+//  2. An array of OCI CloudEvents envelopes
+//  3. An array of OCI Streaming messages (SCH format) — each envelope's
+//     "value" field is base64-decoded to extract the inner OCI Cloud Event.
+//
+// Events are returned as RawMessage so downstream chunking can operate on
+// encoded sizes without re-encoding each element.
 func Decode(in io.Reader) ([]json.RawMessage, error) {
 	var body json.RawMessage
 	if err := json.NewDecoder(in).Decode(&body); err != nil {
@@ -26,6 +73,9 @@ func Decode(in io.Reader) ([]json.RawMessage, error) {
 
 	var arr []json.RawMessage
 	if err := json.Unmarshal(body, &arr); err == nil {
+		if isStreamingFormat(arr) {
+			return decodeStreamingMessages(arr)
+		}
 		return arr, nil
 	}
 

--- a/datadog-functions/events-forwarder/internal/formatter/formatter.go
+++ b/datadog-functions/events-forwarder/internal/formatter/formatter.go
@@ -17,31 +17,23 @@ type streamingMessage struct {
 	Value string `json:"value"`
 }
 
-// isStreamingFormat reports whether msgs looks like an SCH streaming batch:
-// each element has a "value" field but no "eventType" field (which is
-// mandatory in every OCI Cloud Event envelope).
-func isStreamingFormat(msgs []json.RawMessage) bool {
-	if len(msgs) == 0 {
-		return false
-	}
-	var first map[string]json.RawMessage
-	if err := json.Unmarshal(msgs[0], &first); err != nil {
-		return false
-	}
-	_, hasValue := first["value"]
-	_, hasEventType := first["eventType"]
-	return hasValue && !hasEventType
-}
+// Intake limits enforced by cloudplatform-intake/api/v2/cloudchanges.
+const (
+	MaxBodyBytes  = 5 * 1024 * 1024
+	MaxBatchCount = 65536
+)
 
-// decodeStreamingMessages base64-decodes the "value" field of each SCH
-// streaming message and returns the inner OCI Cloud Event JSON payloads.
-func decodeStreamingMessages(msgs []json.RawMessage) ([]json.RawMessage, error) {
+// Decode accepts an array of OCI Streaming messages as delivered by Service
+// Connector Hub. Each message's "value" field is base64-decoded to extract
+// the inner OCI Cloud Event JSON. Events are returned as RawMessage so
+// downstream chunking can operate on encoded sizes without re-encoding.
+func Decode(in io.Reader) ([]json.RawMessage, error) {
+	var msgs []streamingMessage
+	if err := json.NewDecoder(in).Decode(&msgs); err != nil {
+		return nil, fmt.Errorf("failed to decode JSON: %w", err)
+	}
 	out := make([]json.RawMessage, 0, len(msgs))
-	for i, msg := range msgs {
-		var sm streamingMessage
-		if err := json.Unmarshal(msg, &sm); err != nil {
-			return nil, fmt.Errorf("streaming message %d: failed to unmarshal: %w", i, err)
-		}
+	for i, sm := range msgs {
 		decoded, err := base64.StdEncoding.DecodeString(sm.Value)
 		if err != nil {
 			return nil, fmt.Errorf("streaming message %d: failed to base64-decode value: %w", i, err)
@@ -49,41 +41,6 @@ func decodeStreamingMessages(msgs []json.RawMessage) ([]json.RawMessage, error) 
 		out = append(out, json.RawMessage(decoded))
 	}
 	return out, nil
-}
-
-// Intake limits enforced by cloudplatform-intake/api/v2/cloudchanges.
-const (
-	MaxBodyBytes  = 5 * 1024 * 1024
-	MaxBatchCount = 65536
-)
-
-// Decode accepts:
-//  1. A single OCI CloudEvents envelope
-//  2. An array of OCI CloudEvents envelopes
-//  3. An array of OCI Streaming messages (SCH format) — each envelope's
-//     "value" field is base64-decoded to extract the inner OCI Cloud Event.
-//
-// Events are returned as RawMessage so downstream chunking can operate on
-// encoded sizes without re-encoding each element.
-func Decode(in io.Reader) ([]json.RawMessage, error) {
-	var body json.RawMessage
-	if err := json.NewDecoder(in).Decode(&body); err != nil {
-		return nil, fmt.Errorf("failed to decode JSON: %w", err)
-	}
-
-	var arr []json.RawMessage
-	if err := json.Unmarshal(body, &arr); err == nil {
-		if isStreamingFormat(arr) {
-			return decodeStreamingMessages(arr)
-		}
-		return arr, nil
-	}
-
-	var obj map[string]any
-	if err := json.Unmarshal(body, &obj); err != nil {
-		return nil, fmt.Errorf("invalid JSON format: expected object or array of objects: %w", err)
-	}
-	return []json.RawMessage{body}, nil
 }
 
 // Chunk splits events into JSON-array payloads that respect the intake's

--- a/datadog-functions/events-forwarder/internal/formatter/formatter_test.go
+++ b/datadog-functions/events-forwarder/internal/formatter/formatter_test.go
@@ -2,6 +2,7 @@ package formatter
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -40,6 +41,55 @@ func TestDecode_InvalidJSON(t *testing.T) {
 func TestDecode_NotObjectOrArray(t *testing.T) {
 	if _, err := Decode(bytes.NewBufferString("123")); err == nil {
 		t.Fatal("expected error for non-object/array JSON, got nil")
+	}
+}
+
+// schMessage wraps an OCI Cloud Event as Service Connector Hub delivers it
+// when the source is OCI Streaming.
+func schMessage(event string) string {
+	encoded := base64.StdEncoding.EncodeToString([]byte(event))
+	return `{"streamPool":"ocid1.streampool.oc1..test","stream":"ocid1.stream.oc1..test","partition":"0","key":"","value":"` + encoded + `","offset":"0","timestamp":"2024-01-15T10:00:00.000Z"}`
+}
+
+func TestDecode_SCHStreamingArray(t *testing.T) {
+	msg1 := schMessage(sampleEvent)
+	msg2 := schMessage(sampleEvent)
+	in := bytes.NewBufferString("[" + msg1 + "," + msg2 + "]")
+
+	events, err := Decode(in)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2", len(events))
+	}
+	// Each decoded event should be the original OCI Cloud Event JSON.
+	var decoded map[string]any
+	if err := json.Unmarshal(events[0], &decoded); err != nil {
+		t.Fatalf("unmarshal decoded event: %v", err)
+	}
+	if decoded["eventType"] != "com.oraclecloud.objectstorage.deletebucket" {
+		t.Fatalf("eventType = %q, want %q", decoded["eventType"], "com.oraclecloud.objectstorage.deletebucket")
+	}
+}
+
+func TestDecode_SCHStreamingSingleMessage(t *testing.T) {
+	msg := schMessage(sampleEvent)
+	in := bytes.NewBufferString("[" + msg + "]")
+
+	events, err := Decode(in)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+}
+
+func TestDecode_SCHStreamingInvalidBase64(t *testing.T) {
+	bad := `[{"streamPool":"x","value":"!!!notbase64!!!"}]`
+	if _, err := Decode(bytes.NewBufferString(bad)); err == nil {
+		t.Fatal("expected error for invalid base64, got nil")
 	}
 }
 

--- a/datadog-functions/events-forwarder/internal/formatter/formatter_test.go
+++ b/datadog-functions/events-forwarder/internal/formatter/formatter_test.go
@@ -78,11 +78,12 @@ func TestDecode_SCHStreamingEmptyValue(t *testing.T) {
 	}
 }
 
-func TestDecode_SCHStreamingNonJSONValue(t *testing.T) {
-	encoded := base64.StdEncoding.EncodeToString([]byte("not json at all"))
+func TestDecode_SCHStreamingNonObjectValue(t *testing.T) {
+	// A scalar is syntactically valid JSON but not an OCI Cloud Event object.
+	encoded := base64.StdEncoding.EncodeToString([]byte("42"))
 	msg := `[{"streamPool":"x","value":"` + encoded + `"}]`
 	if _, err := Decode(bytes.NewBufferString(msg)); err == nil {
-		t.Fatal("expected error for non-JSON decoded value, got nil")
+		t.Fatal("expected error for non-object decoded value, got nil")
 	}
 }
 

--- a/datadog-functions/events-forwarder/internal/formatter/formatter_test.go
+++ b/datadog-functions/events-forwarder/internal/formatter/formatter_test.go
@@ -10,28 +10,6 @@ import (
 
 const sampleEvent = `{"eventType":"com.oraclecloud.objectstorage.deletebucket","eventID":"abc","data":{"resourceId":"ocid1.bucket.oc1..xyz"}}`
 
-func TestDecode_Array(t *testing.T) {
-	in := bytes.NewBufferString("[" + sampleEvent + "," + sampleEvent + "]")
-	events, err := Decode(in)
-	if err != nil {
-		t.Fatalf("Decode: %v", err)
-	}
-	if len(events) != 2 {
-		t.Fatalf("got %d events, want 2", len(events))
-	}
-}
-
-func TestDecode_SingleObject(t *testing.T) {
-	in := bytes.NewBufferString(sampleEvent)
-	events, err := Decode(in)
-	if err != nil {
-		t.Fatalf("Decode: %v", err)
-	}
-	if len(events) != 1 {
-		t.Fatalf("got %d events, want 1", len(events))
-	}
-}
-
 func TestDecode_InvalidJSON(t *testing.T) {
 	if _, err := Decode(bytes.NewBufferString("not json")); err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")

--- a/datadog-functions/events-forwarder/internal/formatter/formatter_test.go
+++ b/datadog-functions/events-forwarder/internal/formatter/formatter_test.go
@@ -71,6 +71,21 @@ func TestDecode_SCHStreamingInvalidBase64(t *testing.T) {
 	}
 }
 
+func TestDecode_SCHStreamingEmptyValue(t *testing.T) {
+	empty := `[{"streamPool":"x","value":""}]`
+	if _, err := Decode(bytes.NewBufferString(empty)); err == nil {
+		t.Fatal("expected error for empty decoded value, got nil")
+	}
+}
+
+func TestDecode_SCHStreamingNonJSONValue(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("not json at all"))
+	msg := `[{"streamPool":"x","value":"` + encoded + `"}]`
+	if _, err := Decode(bytes.NewBufferString(msg)); err == nil {
+		t.Fatal("expected error for non-JSON decoded value, got nil")
+	}
+}
+
 func TestChunk_FitsInOnePayload(t *testing.T) {
 	events := []json.RawMessage{json.RawMessage(sampleEvent), json.RawMessage(sampleEvent)}
 	payloads, dropped := Chunk(events)

--- a/datadog-functions/events-forwarder/internal/formatter/formatter_test.go
+++ b/datadog-functions/events-forwarder/internal/formatter/formatter_test.go
@@ -87,6 +87,25 @@ func TestDecode_SCHStreamingNonObjectValue(t *testing.T) {
 	}
 }
 
+func TestDecode_SCHStreamingMalformedObjectValue(t *testing.T) {
+	// Starts with '{' but is not valid JSON — json.Valid should reject it.
+	encoded := base64.StdEncoding.EncodeToString([]byte("{not valid json"))
+	msg := `[{"streamPool":"x","value":"` + encoded + `"}]`
+	if _, err := Decode(bytes.NewBufferString(msg)); err == nil {
+		t.Fatal("expected error for malformed JSON object, got nil")
+	}
+}
+
+func TestDecode_EmptyArray(t *testing.T) {
+	events, err := Decode(bytes.NewBufferString("[]"))
+	if err != nil {
+		t.Fatalf("unexpected error for empty array: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("got %d events, want 0", len(events))
+	}
+}
+
 func TestChunk_FitsInOnePayload(t *testing.T) {
 	events := []json.RawMessage{json.RawMessage(sampleEvent), json.RawMessage(sampleEvent)}
 	payloads, dropped := Chunk(events)

--- a/datadog-functions/events-forwarder/internal/handler/handler_test.go
+++ b/datadog-functions/events-forwarder/internal/handler/handler_test.go
@@ -40,14 +40,7 @@ func schBatch(events ...string) string {
 		encoded := base64.StdEncoding.EncodeToString([]byte(ev))
 		msgs[i] = `{"value":"` + encoded + `"}`
 	}
-	result := "["
-	for i, m := range msgs {
-		if i > 0 {
-			result += ","
-		}
-		result += m
-	}
-	return result + "]"
+	return "[" + strings.Join(msgs, ",") + "]"
 }
 
 func withTestClient(t *testing.T) {

--- a/datadog-functions/events-forwarder/internal/handler/handler_test.go
+++ b/datadog-functions/events-forwarder/internal/handler/handler_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"os"
@@ -32,6 +33,23 @@ func (mockFnContext) TracingContextData() fdk.TracingContext { return nil }
 
 const eventEnvelope = `{"eventType":"com.oraclecloud.objectstorage.deletebucket","eventID":"abc","data":{"resourceId":"ocid1.bucket.oc1..xyz"}}`
 
+// schBatch wraps one or more OCI Cloud Events as an SCH OCI Streaming batch.
+func schBatch(events ...string) string {
+	msgs := make([]string, len(events))
+	for i, ev := range events {
+		encoded := base64.StdEncoding.EncodeToString([]byte(ev))
+		msgs[i] = `{"value":"` + encoded + `"}`
+	}
+	result := "["
+	for i, m := range msgs {
+		if i > 0 {
+			result += ","
+		}
+		result += m
+	}
+	return result + "]"
+}
+
 func withTestClient(t *testing.T) {
 	t.Helper()
 	t.Setenv("TENANCY_OCID", "ocid1.tenancy.oc1..test")
@@ -56,7 +74,7 @@ func runHandler(t *testing.T, body string) fnResponse {
 func TestMyHandler_ArrayPayload(t *testing.T) {
 	withTestClient(t)
 
-	resp := runHandler(t, "["+eventEnvelope+","+eventEnvelope+"]")
+	resp := runHandler(t, schBatch(eventEnvelope, eventEnvelope))
 	if resp.Status != "success" {
 		t.Fatalf("status = %q, want success (resp=%+v)", resp.Status, resp)
 	}
@@ -68,7 +86,7 @@ func TestMyHandler_ArrayPayload(t *testing.T) {
 func TestMyHandler_SingleEnvelope(t *testing.T) {
 	withTestClient(t)
 
-	resp := runHandler(t, eventEnvelope)
+	resp := runHandler(t, schBatch(eventEnvelope))
 	if resp.Status != "success" {
 		t.Fatalf("status = %q, want success (resp=%+v)", resp.Status, resp)
 	}
@@ -93,7 +111,7 @@ func TestMyHandler_MissingTenancyOCID(t *testing.T) {
 
 	os.Unsetenv("TENANCY_OCID")
 
-	resp := runHandler(t, eventEnvelope)
+	resp := runHandler(t, schBatch(eventEnvelope))
 	if resp.Status != "error" {
 		t.Fatalf("status = %q, want error", resp.Status)
 	}
@@ -110,7 +128,7 @@ func TestMyHandler_MissingDDSite(t *testing.T) {
 	t.Setenv("TENANCY_OCID", "ocid1.tenancy.oc1..test")
 	os.Unsetenv("DD_SITE")
 
-	resp := runHandler(t, eventEnvelope)
+	resp := runHandler(t, schBatch(eventEnvelope))
 	if resp.Status != "error" {
 		t.Fatalf("status = %q, want error", resp.Status)
 	}


### PR DESCRIPTION
## Summary

- Decode SCH OCI Streaming envelopes by base64-decoding each message's `value` field before forwarding to Datadog
- Simplify `Decode` to handle only SCH OCI Streaming format (single JSON pass into `[]streamingMessage`), removing the `isStreamingFormat` heuristic and multi-path fallback
- Update handler and formatter tests to use SCH-wrapped payloads via a new `schBatch` helper

## Test plan

- [ ] `go test ./...` passes in `datadog-functions/events-forwarder`
- [ ] `TestDecode_SCHStreamingArray` / `TestDecode_SCHStreamingSingleMessage` verify base64 unwrapping
- [ ] `TestMyHandler_ArrayPayload` / `TestMyHandler_SingleEnvelope` verify end-to-end handler with SCH format
- [ ] `TestMyHandler_MissingTenancyOCID` / `TestMyHandler_MissingDDSite` correctly reach env-var validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)