### PR TITLE
Pin oracle-terraform-modules/vcn/oci to ~> 3.6 to block 4.0 breaking change

### DIFF
--- a/datadog-terraform-onboarding/modules/regional-stacks/main.tf
+++ b/datadog-terraform-onboarding/modules/regional-stacks/main.tf
@@ -38,7 +38,7 @@ resource "oci_functions_function" "metrics_function" {
 module "vcn" {
   count                    = var.subnet_ocid == "" ? 1 : 0
   source                   = "oracle-terraform-modules/vcn/oci"
-  version                  = ">= 3.6.0"
+  version                  = "~> 3.6"
   compartment_id           = var.compartment_ocid
   freeform_tags            = var.tags
   defined_tags             = var.defined_tags
@@ -58,7 +58,7 @@ module "vcn" {
 module "subnet" {
   count          = var.subnet_ocid == "" ? 1 : 0
   source         = "oracle-terraform-modules/vcn/oci//modules/subnet"
-  version        = ">= 3.6.0"
+  version        = "~> 3.6"
   compartment_id = var.compartment_ocid
   vcn_id         = module.vcn[0].vcn_id
   nat_route_id   = module.vcn[0].nat_route_id


### PR DESCRIPTION
## Summary

- `oracle-terraform-modules/vcn/oci` released [v4.0.0](https://github.com/oracle-terraform-modules/terraform-oci-vcn/releases/tag/v4.0.0) on 2026-06-19 ([PR #144](https://github.com/oracle-terraform-modules/terraform-oci-vcn/pull/144)), which made `tenancy_id` a **required** argument on the `vcn` module
- Our previous constraint `>= 3.6.0` was pulling in 4.0.0 during `terraform init`, breaking `terraform validate` in CI
- This PR tightens the constraint to `~> 3.6` for both `module "vcn"` and `module "subnet"` to stay on 3.x
- A follow-up PR will adopt the 4.0 API by adding `tenancy_id = var.tenancy_ocid`

## Test plan

- [ ] CI `terraform validate` passes on both TF 1.5.7 and latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)