### PR TITLE
Update SKILL for building the datadog-integration zip

### DIFF
--- a/.claude/skills/datadog-onboarding-testing/SKILL.md
+++ b/.claude/skills/datadog-onboarding-testing/SKILL.md
@@ -263,6 +263,7 @@ Deploy via Resource Manager using a **local zip** of the module (not the GitHub 
 
 ```bash
 cd datadog-integration
+cp ../VERSION .
 zip -rq /tmp/datadog-integration-onboarding-test.zip ./*
 ```
 


### PR DESCRIPTION
**what**

Added instructions for copying VERSION file and zipping the integration.

**why**

integration will fail at the end. very sad