### PR TITLE
ECI-1662 Log every backfill invocation to OCI logging

### DIFF
--- a/datadog-functions/lib/client/client.go
+++ b/datadog-functions/lib/client/client.go
@@ -339,6 +339,7 @@ func (client *DatadogClient) Backfill(ctx context.Context, intakeURL string, ext
 	if err != nil {
 		return BackfillSummary{}, err
 	}
+	log.Printf("backfill: invoked with backfill_mode=true for bucket %q", bucket)
 
 	osClient, err := newObjectStorageClientFunc()
 	if err != nil {


### PR DESCRIPTION
## What
Adds a single log line at the top of `DatadogClient.Backfill` (shared by the events/logs/metrics forwarders) recording that a backfill replay was invoked, including the resolved backfill bucket name.

## Why
hubmanager's backfill trigger invoke is detached/fire-and-forget (`FnInvokeTypeDetached`) — there's no synchronous response for the caller to observe. Without this, there's no way to confirm from the OCI side that a given invoke actually started draining a bucket. Uses the plain `log` package (stdout/stderr, captured by OCI Logging), not the Datadog client, since backfill mode is specifically for when Datadog may be unreachable.

## Testing
`go build ./...` and `go test ./...` pass for `datadog-functions/lib/client`. Not yet validated against a live OCI Logging search — will confirm the log line surfaces there before merging.