### PR TITLE
ECI-1895: Fail loudly on docker image build/push and login failures

### DIFF
--- a/datadog-functions/docker-images.sh
+++ b/datadog-functions/docker-images.sh
@@ -50,6 +50,8 @@ fi
 # Ensure buildx is initialized
 docker buildx create --use --name multiarch-builder >/dev/null 2>&1 || docker buildx use multiarch-builder
 
+FAILED_ITEMS=()
+
 build_and_push_image() {
   IMAGE_PATH=$1
   REGISTRY=$2
@@ -66,7 +68,10 @@ build_and_push_image() {
   if [ $? -eq 0 ]; then
     echo "Successfully built and pushed ${IMAGE_PATH}:${TAG} and :latest"
   else
-    echo "Failed to build and push image for $IMAGE_PATH"
+    echo "############################################################"
+    echo "## FAILED to build and push image for $IMAGE_PATH"
+    echo "############################################################"
+    FAILED_ITEMS+=("$IMAGE_PATH")
   fi
 }
 
@@ -86,7 +91,10 @@ for TARGET in "${BUILD_TARGETS[@]}"; do
   echo "Logging in to $REGISTRY..."
   echo "$PASSWORD" | docker login "$REGISTRY" --username "$LOGIN_USER" --password-stdin
   if [ $? -ne 0 ]; then
-    echo "Login failed for $REGISTRY"
+    echo "############################################################"
+    echo "## LOGIN FAILED for $REGISTRY"
+    echo "############################################################"
+    FAILED_ITEMS+=("login:$REGISTRY")
     continue
   fi
 
@@ -97,3 +105,16 @@ done
 
 # Clear the password from memory
 unset PASSWORD
+
+if [ ${#FAILED_ITEMS[@]} -gt 0 ]; then
+  echo ""
+  echo "############################################################"
+  echo "## BUILD/PUSH COMPLETED WITH FAILURES:"
+  for ITEM in "${FAILED_ITEMS[@]}"; do
+    echo "##   - $ITEM"
+  done
+  echo "############################################################"
+  exit 1
+fi
+
+echo "All images built and pushed successfully in all regions."


### PR DESCRIPTION
## What
Makes `datadog-functions/docker-images.sh` fail loudly when a region's Docker login, image build, or image push fails: each failure now prints a boxed banner, is recorded in a `FAILED_ITEMS` list, and the script exits non-zero with a full failure summary at the end (instead of continuing silently to success).

## Why
Previously, a failed login or `docker buildx build --push` for a given region only printed a single easy-to-miss line and the loop moved on; the script always exited 0 regardless of failures. Since a missed image in a region can silently break the Datadog forwarder there, failures need to be impossible to overlook. ECI-1895.

## Testing
Manually reviewed the script logic for correctness (bash syntax, `FAILED_ITEMS` accumulation across both login and build/push failure paths, non-zero exit only when failures occurred). No CI/test runner exists for this standalone operator script; not run end-to-end against real OCI credentials.