### PR TITLE
Log backfill completion to OCI logging

### DIFF
--- a/datadog-functions/lib/client/client.go
+++ b/datadog-functions/lib/client/client.go
@@ -464,7 +464,11 @@ producer:
 	if fatalErr != nil {
 		return summary, fatalErr
 	}
-	return summary, listErr
+	if listErr != nil {
+		return summary, listErr
+	}
+	log.Printf("backfill: complete for bucket %q: %s", bucket, summary.String())
+	return summary, nil
 }
 
 // replayWithRetry sends a replayed payload, retrying once on failure. On a 429 it

--- a/datadog-functions/lib/client/client.go
+++ b/datadog-functions/lib/client/client.go
@@ -468,7 +468,60 @@ producer:
 		return summary, listErr
 	}
 	log.Printf("backfill: complete for bucket %q: %s", bucket, summary.String())
+	// Reaching here means every replay in this run already succeeded against
+	// Datadog, so intake is provably reachable right now — safe to notify
+	// Datadog directly rather than relying solely on OCI Logging. Skipped when
+	// nothing was actually replayed (an empty-bucket no-op run), so this stays a
+	// signal about real backfilled data rather than noise on every empty check.
+	if summary.Replayed > 0 {
+		client.notifyBackfillComplete(ctx, bucket, summary)
+	}
 	return summary, nil
+}
+
+// backfillCompleteLog is the payload sent to Datadog's Logs API on a successful
+// backfill completion. Fields beyond message/ddsource/service become facets in
+// Log Explorer.
+type backfillCompleteLog struct {
+	Message        string `json:"message"`
+	DDSource       string `json:"ddsource"`
+	Service        string `json:"service"`
+	Bucket         string `json:"bucket"`
+	Replayed       int    `json:"replayed"`
+	Skipped        int    `json:"skipped"`
+	Dropped        int    `json:"dropped"`
+	DeleteFailures int    `json:"delete_failures"`
+}
+
+// notifyBackfillComplete sends a log event to Datadog's Logs API reporting a
+// successful backfill completion. Best-effort: a failure here only logs to OCI
+// and never changes Backfill's returned error, since this is an observability
+// signal, not the replay itself.
+func (client *DatadogClient) notifyBackfillComplete(ctx context.Context, bucket string, summary BackfillSummary) {
+	site := os.Getenv("DD_SITE")
+	if site == "" {
+		log.Printf("backfill: skipping completion notify for bucket %q: DD_SITE not set", bucket)
+		return
+	}
+	entry := backfillCompleteLog{
+		Message:        fmt.Sprintf("backfill complete for bucket %q: %s", bucket, summary.String()),
+		DDSource:       "oci-backfill",
+		Service:        "oci-hubmanager-backfill",
+		Bucket:         bucket,
+		Replayed:       summary.Replayed,
+		Skipped:        summary.Skipped,
+		Dropped:        summary.Dropped,
+		DeleteFailures: summary.DeleteFailures,
+	}
+	payload, err := json.Marshal([]backfillCompleteLog{entry})
+	if err != nil {
+		log.Printf("backfill: failed to marshal completion notify for bucket %q: %v", bucket, err)
+		return
+	}
+	logsURL := fmt.Sprintf("https://http-intake.logs.%s/api/v2/logs", site)
+	if err := client.SendMessageToDatadog(ctx, payload, logsURL); err != nil {
+		log.Printf("backfill: failed to notify Datadog of completion for bucket %q: %v", bucket, err)
+	}
 }
 
 // replayWithRetry sends a replayed payload, retrying once on failure. On a 429 it


### PR DESCRIPTION
## What
Two related additions to `Backfill()`'s success path, both firing only on a genuinely clean completion (no fatal replay error, no list error):
1. `log.Printf` logging the summary (`replayed`/`skipped`/`dropped`/`delete_failures`) — captured by OCI Logging.
2. A direct log event sent to Datadog's Logs API (`https://http-intake.logs.<site>/api/v2/logs`), skipped when `summary.Replayed == 0` so an empty-bucket no-op run doesn't generate noise.

## Why
`writeResponse(out, "success", "Backfill complete: "+summary.String(), nil)` only writes that message into the function's HTTP response body — but `hubmanager`'s invoke is detached, so nobody ever reads that response. A successful backfill drain previously left no durable trace anywhere. The error path already calls `log.Println(err)` before `writeResponse`, so failures do show up in OCI Logging; part 1 closes the equivalent gap for the success/completion case. Companion to #160, which added the equivalent "invoked" signal at the start of a run.

Part 2 sends the same signal directly to Datadog. Normally we'd be wary of that — backfill exists because the customer's Datadog pipe might be degraded, so routing observability about it back through the same pipe is circular. But by the time `Backfill()` reaches its success return, every object in this run has already been replayed successfully against Datadog, which proves intake is reachable *right now* — so notifying Datadog directly at that specific point doesn't have the same risk the "invoked" signal would.

## Testing
`go build ./...`, `go vet ./...`, and `go test ./...` pass for `datadog-functions/lib/client`.