### PR TITLE
Clean up Quickstart networking

### DIFF
--- a/oci-integration-cleanup/integration_cleanup.py
+++ b/oci-integration-cleanup/integration_cleanup.py
@@ -26,6 +26,7 @@ from oci_cleanup import __all__ as package_api
 from oci_cleanup.base import CleanupBase
 from oci_cleanup.discovery import DiscoveryMixin
 from oci_cleanup.domains.extras import ExtrasMixin
+from oci_cleanup.domains.network import NetworkMixin
 from oci_cleanup.engine import EngineMixin
 from oci_cleanup.region import RegionMixin
 
@@ -37,9 +38,10 @@ class QuickstartCleanup(
     DiscoveryMixin,
     ExtrasMixin,
     RegionMixin,
+    NetworkMixin,
     CleanupBase,
 ):
-    """Discover unexpected resources in one OCI Quickstart installation."""
+    """Discover and remove Quickstart networking resources."""
 
 
 def _parse_bool(value: str) -> bool:

--- a/oci-integration-cleanup/oci_cleanup/domains/network.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/network.py
@@ -1,0 +1,388 @@
+"""Responsibility: clean the Datadog VCN, subnet, gateways, and route dependencies.
+
+Safety boundary: validates exact ownership and blocks parents with unapproved nested resources.
+Cleanup sequence role: runs after forwarding services and before regional KMS cleanup.
+
+``NetworkMixin.cleanup_network`` dismantles route rules, gateways, subnets, and the
+VCN in dependency order, consulting extra-resource approvals before parent removal.
+Subnet deletion retries while service-created VNICs detach and records hard blockers.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from ..constants import (
+    LOGGER,
+    NAT_GATEWAY_NAME,
+    SERVICE_GATEWAY_NAME,
+    SUBNET_NAME,
+    SUBNET_VNIC_RETRY_INTERVAL_SECONDS,
+    SUBNET_VNIC_RETRY_SECONDS,
+    VCN_NAME,
+)
+from ..errors import CommandError
+from ..models import CleanupContext
+from ..resources import (
+    exact_owned,
+    is_owned,
+    resource_field,
+    resource_id,
+    resource_name,
+)
+
+
+class NetworkMixin:
+    """Remove the validated Quickstart network and its dependencies."""
+
+    def _block_network_dependents(self, region: str, reason: str) -> None:
+        description = (
+            "Preserve route tables, gateways, and VCN because "
+            f"{reason}"
+        )
+        self.planned.append(
+            {
+                "id": f"network-dependents:{region}",
+                "description": description,
+                "status": "blocked",
+            }
+        )
+        self.manifest.record_action(
+            f"network-dependents:{region}",
+            description,
+            "blocked",
+            region=region,
+        )
+        if self.execute:
+            self.manifest.save()
+
+    def cleanup_network(self, context: CleanupContext, region: str) -> None:
+        network_extra_kinds = {
+            "secondary-vnic",
+            "unverified-secondary-vnic",
+            "compute-instance",
+            "subnet",
+            "route-table",
+            "nat-gateway",
+            "service-gateway",
+            "internet-gateway",
+            "local-peering-gateway",
+        }
+        approved_extras_deleted = self._delete_approved_extras(
+            region=region, kinds=network_extra_kinds
+        )
+        network_dependencies_blocked = any(
+            candidate.region == region
+            and candidate.kind in network_extra_kinds | {"unsupported-vnic"}
+            and not self._candidate_is_approved(candidate)
+            for candidate in self.extra_candidates
+        )
+        if not approved_extras_deleted:
+            self._block_network_dependents(
+                region, "an approved nested-resource deletion failed"
+            )
+            return
+        vcns = self._list_region(
+            region,
+            [
+                "network",
+                "vcn",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+            ],
+        )
+        owned_vcns = [
+            vcn
+            for vcn in vcns
+            if exact_owned(
+                vcn,
+                expected_names={VCN_NAME},
+                compartment_id=context.compartment_id,
+            )
+        ]
+        owned_vcn_ids = {resource_id(vcn) for vcn in owned_vcns}
+        nat_gateways = self._list_region(
+            region,
+            [
+                "network",
+                "nat-gateway",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+            ],
+        )
+        service_gateways = self._list_region(
+            region,
+            [
+                "network",
+                "service-gateway",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+            ],
+        )
+        owned_gateway_ids = {
+            resource_id(gateway)
+            for gateway, expected_name in [
+                *[(gateway, NAT_GATEWAY_NAME) for gateway in nat_gateways],
+                *[
+                    (gateway, SERVICE_GATEWAY_NAME)
+                    for gateway in service_gateways
+                ],
+            ]
+            if exact_owned(
+                gateway,
+                expected_names={expected_name},
+                compartment_id=context.compartment_id,
+            )
+        }
+        default_route_table_ids = {
+            str(
+                resource_field(vcn, "default-route-table-id", "")
+            )
+            for vcn in owned_vcns
+        }
+        default_route_table_ids.discard("")
+
+        subnets = self._list_region(
+            region,
+            [
+                "network",
+                "subnet",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+            ],
+        )
+        for subnet in subnets:
+            if not exact_owned(
+                subnet,
+                expected_names={SUBNET_NAME},
+                compartment_id=context.compartment_id,
+            ):
+                continue
+            subnet_id = resource_id(subnet)
+            if self._has_unapproved_extra(region=region, container_id=subnet_id):
+                action_id = f"subnet:{region}:{subnet_id}"
+                description = (
+                    f"Preserve Quickstart subnet {subnet_id} because an "
+                    "attached resource was not approved or requires manual "
+                    "remediation"
+                )
+                self.planned.append(
+                    {
+                        "id": action_id,
+                        "description": description,
+                        "status": "blocked",
+                    }
+                )
+                self.manifest.record_action(
+                    action_id,
+                    description,
+                    "blocked",
+                    resource_id=subnet_id,
+                    region=region,
+                )
+                if self.execute:
+                    self.manifest.save()
+                network_dependencies_blocked = True
+                continue
+            deleted = self.action(
+                f"subnet:{region}:{subnet_id}",
+                f"Delete Quickstart subnet {SUBNET_NAME} ({subnet_id}) in {region}",
+                function=lambda subnet_id=subnet_id: self._delete_subnet_after_vnic_detach(
+                    region, subnet_id
+                ),
+                details={"resource_id": subnet_id, "region": region},
+                retry_completed=True,
+            )
+            if not deleted:
+                network_dependencies_blocked = True
+
+        if network_dependencies_blocked:
+            self._block_network_dependents(
+                region, "a subnet or nested network dependency remains"
+            )
+            return
+
+        route_tables = self._list_region(
+            region,
+            [
+                "network",
+                "route-table",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+            ],
+        )
+        for route_table in route_tables:
+            identifier = resource_id(route_table)
+            route_table_vcn_id = str(
+                resource_field(route_table, "vcn-id", "")
+            )
+            if route_table_vcn_id not in owned_vcn_ids:
+                continue
+            name = resource_name(route_table)
+            is_default = (
+                identifier in default_route_table_ids
+                or name == f"Default Route Table for {VCN_NAME}"
+            )
+            if is_default:
+                route_rules = resource_field(route_table, "route-rules", [])
+                retained_rules = [
+                    rule
+                    for rule in route_rules
+                    if str(
+                        resource_field(rule, "network-entity-id", "")
+                    )
+                    not in owned_gateway_ids
+                ]
+                if len(retained_rules) != len(route_rules):
+                    self.action(
+                        f"route-table-rules:{region}:{identifier}",
+                        "Remove Datadog gateway routes from the Quickstart "
+                        f"VCN default route table {identifier}",
+                        command=[
+                            "--region",
+                            region,
+                            "network",
+                            "route-table",
+                            "update",
+                            "--rt-id",
+                            identifier,
+                            "--route-rules",
+                            json.dumps(retained_rules, separators=(",", ":")),
+                            "--force",
+                        ],
+                        retry_completed=True,
+                    )
+                continue
+            if not is_owned(route_table):
+                continue
+            self.action(
+                f"route-table:{region}:{identifier}",
+                f"Delete route table {name} from owned Quickstart VCN",
+                command=[
+                    "--region",
+                    region,
+                    "network",
+                    "route-table",
+                    "delete",
+                    "--rt-id",
+                    identifier,
+                    "--force",
+                ],
+                retry_completed=True,
+            )
+
+        self._delete_owned_list(
+            region=region,
+            resources=nat_gateways,
+            expected_names={NAT_GATEWAY_NAME},
+            action_prefix="nat-gateway",
+            description="Delete Quickstart NAT gateway",
+            command_builder=lambda resource: [
+                "--region",
+                region,
+                "network",
+                "nat-gateway",
+                "delete",
+                "--nat-gateway-id",
+                resource_id(resource),
+                "--force",
+                "--wait-for-state",
+                "TERMINATED",
+            ],
+            compartment_id=context.compartment_id,
+            retry_completed=True,
+        )
+
+        self._delete_owned_list(
+            region=region,
+            resources=service_gateways,
+            expected_names={SERVICE_GATEWAY_NAME},
+            action_prefix="service-gateway",
+            description="Delete Quickstart service gateway",
+            command_builder=lambda resource: [
+                "--region",
+                region,
+                "network",
+                "service-gateway",
+                "delete",
+                "--service-gateway-id",
+                resource_id(resource),
+                "--force",
+                "--wait-for-state",
+                "TERMINATED",
+            ],
+            compartment_id=context.compartment_id,
+            retry_completed=True,
+        )
+
+        self._delete_owned_list(
+            region=region,
+            resources=vcns,
+            expected_names={VCN_NAME},
+            action_prefix="vcn",
+            description="Delete Quickstart VCN",
+            command_builder=lambda resource: [
+                "--region",
+                region,
+                "network",
+                "vcn",
+                "delete",
+                "--vcn-id",
+                resource_id(resource),
+                "--force",
+                "--wait-for-state",
+                "TERMINATED",
+            ],
+            compartment_id=context.compartment_id,
+            retry_completed=True,
+        )
+
+    def _delete_subnet_after_vnic_detach(
+        self, region: str, subnet_id: str
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + SUBNET_VNIC_RETRY_SECONDS
+        command = [
+            "--region",
+            region,
+            "network",
+            "subnet",
+            "delete",
+            "--subnet-id",
+            subnet_id,
+            "--force",
+            "--wait-for-state",
+            "TERMINATED",
+        ]
+        while True:
+            try:
+                return self.oci.run(
+                    command,
+                    attempts=3,
+                    allow_not_found=True,
+                )
+            except CommandError as error:
+                retryable = (
+                    "Conflict" in error.stderr
+                    and "references the VNIC" in error.stderr
+                )
+                remaining = deadline - time.monotonic()
+                if not retryable or remaining <= 0:
+                    raise
+                delay = min(SUBNET_VNIC_RETRY_INTERVAL_SECONDS, remaining)
+                LOGGER.warning(
+                    "Subnet %s still references a VNIC; retrying deletion in "
+                    "%d seconds (up to %d seconds remaining)",
+                    subnet_id,
+                    round(delay),
+                    round(remaining),
+                )
+                time.sleep(delay)
+
+

--- a/oci-integration-cleanup/oci_cleanup/domains/network.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/network.py
@@ -380,5 +380,3 @@ class NetworkMixin:
                     round(remaining),
                 )
                 time.sleep(delay)
-
-

--- a/oci-integration-cleanup/oci_cleanup/domains/network.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/network.py
@@ -42,21 +42,22 @@ class NetworkMixin:
             "Preserve route tables, gateways, and VCN because "
             f"{reason}"
         )
+        failure = self._record_failure(
+            description,
+            region=region,
+            deletion_message=description,
+        )
         self.planned.append(
             {
                 "id": f"network-dependents:{region}",
                 "description": description,
                 "status": "blocked",
+                "resource_id": "",
+                "region": region,
+                "error_code": failure["error_code"],
+                "deletion_message": failure["deletion_message"],
             }
         )
-        self.manifest.record_action(
-            f"network-dependents:{region}",
-            description,
-            "blocked",
-            region=region,
-        )
-        if self.execute:
-            self.manifest.save()
 
     def cleanup_network(self, context: CleanupContext, region: str) -> None:
         network_extra_kinds = {
@@ -172,22 +173,23 @@ class NetworkMixin:
                     "attached resource was not approved or requires manual "
                     "remediation"
                 )
+                failure = self._record_failure(
+                    description,
+                    resource_id=subnet_id,
+                    region=region,
+                    deletion_message=description,
+                )
                 self.planned.append(
                     {
                         "id": action_id,
                         "description": description,
                         "status": "blocked",
+                        "resource_id": subnet_id,
+                        "region": region,
+                        "error_code": failure["error_code"],
+                        "deletion_message": failure["deletion_message"],
                     }
                 )
-                self.manifest.record_action(
-                    action_id,
-                    description,
-                    "blocked",
-                    resource_id=subnet_id,
-                    region=region,
-                )
-                if self.execute:
-                    self.manifest.save()
                 network_dependencies_blocked = True
                 continue
             deleted = self.action(
@@ -197,7 +199,6 @@ class NetworkMixin:
                     region, subnet_id
                 ),
                 details={"resource_id": subnet_id, "region": region},
-                retry_completed=True,
             )
             if not deleted:
                 network_dependencies_blocked = True
@@ -257,7 +258,6 @@ class NetworkMixin:
                             json.dumps(retained_rules, separators=(",", ":")),
                             "--force",
                         ],
-                        retry_completed=True,
                     )
                 continue
             if not is_owned(route_table):
@@ -275,7 +275,6 @@ class NetworkMixin:
                     identifier,
                     "--force",
                 ],
-                retry_completed=True,
             )
 
         self._delete_owned_list(
@@ -297,7 +296,6 @@ class NetworkMixin:
                 "TERMINATED",
             ],
             compartment_id=context.compartment_id,
-            retry_completed=True,
         )
 
         self._delete_owned_list(
@@ -319,7 +317,6 @@ class NetworkMixin:
                 "TERMINATED",
             ],
             compartment_id=context.compartment_id,
-            retry_completed=True,
         )
 
         self._delete_owned_list(
@@ -341,7 +338,6 @@ class NetworkMixin:
                 "TERMINATED",
             ],
             compartment_id=context.compartment_id,
-            retry_completed=True,
         )
 
     def _delete_subnet_after_vnic_detach(

--- a/oci-integration-cleanup/oci_cleanup/region.py
+++ b/oci-integration-cleanup/oci_cleanup/region.py
@@ -10,7 +10,8 @@ class RegionMixin:
     """Coordinate cleanup and failure isolation for each region."""
 
     def cleanup_region(self, context: CleanupContext, region: str) -> None:
-        LOGGER.info("No regional cleanup domains enabled yet in %s", region)
+        LOGGER.info("Cleaning Quickstart networking in %s", region)
+        self.cleanup_network(context, region)
 
 
     def _cleanup_region_safely(

--- a/oci-integration-cleanup/tests/test_integration_cleanup.py
+++ b/oci-integration-cleanup/tests/test_integration_cleanup.py
@@ -871,6 +871,190 @@ class CleanupTestCase(unittest.TestCase):
         )
         self.assertEqual(2, list_region.call_count)
 
+    def test_subnet_deletion_retries_vnic_detach_conflict(self):
+        oci = FakeOci()
+        responses = iter(
+            [
+                cleanup.CommandError(
+                    ["oci", "network", "subnet", "delete"],
+                    1,
+                    "Conflict: The Subnet references the VNIC test-vnic",
+                ),
+                {},
+            ]
+        )
+
+        def delete_subnet():
+            response = next(responses)
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+        oci.add_run("network subnet delete", delete_subnet)
+        cleaner = self.make_cleaner(oci=oci)
+        with patch("oci_cleanup.domains.network.time.sleep") as sleep:
+            cleaner._delete_subnet_after_vnic_detach(HOME_REGION, "test-subnet")
+
+        self.assertEqual(2, len(oci.run_calls))
+        sleep.assert_called_once_with(
+            cleanup.SUBNET_VNIC_RETRY_INTERVAL_SECONDS
+        )
+
+    def test_blocked_subnet_updates_manifest_and_stops_network_dependents(self):
+        oci = FakeOci()
+        oci.add_list(
+            "network vcn list",
+            [
+                owned(
+                    {
+                        "id": "dd-vcn-id",
+                        "display-name": cleanup.VCN_NAME,
+                        "compartment-id": COMPARTMENT,
+                    }
+                )
+            ],
+        )
+        oci.add_list("network nat-gateway list", [])
+        oci.add_list("network service-gateway list", [])
+        oci.add_list(
+            "network subnet list",
+            [
+                owned(
+                    {
+                        "id": "blocked-subnet",
+                        "display-name": cleanup.SUBNET_NAME,
+                        "compartment-id": COMPARTMENT,
+                    }
+                )
+            ],
+        )
+        cleaner = self.make_cleaner(execute=True, oci=oci)
+        cleaner.manifest.record_action(
+            f"subnet:{HOME_REGION}:blocked-subnet",
+            "Old completed subnet deletion",
+            "completed",
+        )
+        cleaner.extra_candidates = [
+            extra_candidate(
+                candidate_id=f"extra:unsupported-vnic:{HOME_REGION}:vnic",
+                kind="unsupported-vnic",
+                resource_id="vnic",
+                container_id="blocked-subnet",
+                command=None,
+            )
+        ]
+
+        cleaner.cleanup_network(context(), HOME_REGION)
+
+        subnet_action = cleaner.manifest.data["actions"][
+            f"subnet:{HOME_REGION}:blocked-subnet"
+        ]
+        self.assertEqual("blocked", subnet_action["status"])
+        self.assertFalse(
+            any(
+                "network route-table list" in " ".join(call)
+                for call in oci.list_calls
+            )
+        )
+        self.assertTrue(
+            any(
+                action["id"] == f"network-dependents:{HOME_REGION}"
+                and action["status"] == "blocked"
+                for action in cleaner.planned
+            )
+        )
+
+    def test_network_deletes_route_tables_before_owned_gateways(self):
+        oci = FakeOci()
+        oci.add_list(
+            "network vcn list",
+            [
+                owned(
+                    {
+                        "id": "dd-vcn-id",
+                        "display-name": cleanup.VCN_NAME,
+                        "compartment-id": COMPARTMENT,
+                        "default-route-table-id": "default-route-table",
+                    }
+                )
+            ],
+        )
+        oci.add_list(
+            "network nat-gateway list",
+            [
+                owned(
+                    {
+                        "id": "nat-gateway",
+                        "display-name": cleanup.NAT_GATEWAY_NAME,
+                        "compartment-id": COMPARTMENT,
+                    }
+                )
+            ],
+        )
+        oci.add_list(
+            "network service-gateway list",
+            [
+                owned(
+                    {
+                        "id": "service-gateway",
+                        "display-name": cleanup.SERVICE_GATEWAY_NAME,
+                        "compartment-id": COMPARTMENT,
+                    }
+                )
+            ],
+        )
+        oci.add_list("network subnet list", [])
+        oci.add_list(
+            "network route-table list",
+            [
+                {
+                    "id": "default-route-table",
+                    "display-name": "Default Route Table for dd-vcn",
+                    "vcn-id": "dd-vcn-id",
+                    "route-rules": [
+                        {"network-entity-id": "nat-gateway"},
+                        {"network-entity-id": "customer-gateway"},
+                    ],
+                },
+                owned(
+                    {
+                        "id": "service-route-table",
+                        "display-name": "service-gw-route",
+                        "vcn-id": "dd-vcn-id",
+                        "route-rules": [
+                            {"network-entity-id": "service-gateway"}
+                        ],
+                    }
+                ),
+            ],
+        )
+        cleaner = self.make_cleaner(oci=oci, execute=True)
+        cleaner.cleanup_network(context(), HOME_REGION)
+
+        commands = [" ".join(call) for call in oci.run_calls]
+        update_index = next(
+            index
+            for index, command in enumerate(commands)
+            if "route-table update" in command
+        )
+        route_delete_index = next(
+            index
+            for index, command in enumerate(commands)
+            if "route-table delete" in command
+        )
+        gateway_delete_index = next(
+            index
+            for index, command in enumerate(commands)
+            if "service-gateway delete" in command
+        )
+        self.assertLess(update_index, gateway_delete_index)
+        self.assertLess(route_delete_index, gateway_delete_index)
+        self.assertIn("customer-gateway", commands[update_index])
+        self.assertNotIn(
+            '"network-entity-id":"nat-gateway"',
+            commands[update_index],
+        )
+
     def test_run_cleans_regions_concurrently(self):
         cleaner = self.make_cleaner(
             args=SimpleNamespace(region_workers=2)

--- a/oci-integration-cleanup/tests/test_integration_cleanup.py
+++ b/oci-integration-cleanup/tests/test_integration_cleanup.py
@@ -900,7 +900,7 @@ class CleanupTestCase(unittest.TestCase):
             cleanup.SUBNET_VNIC_RETRY_INTERVAL_SECONDS
         )
 
-    def test_blocked_subnet_updates_manifest_and_stops_network_dependents(self):
+    def test_blocked_subnet_records_stateless_failures_and_stops_dependents(self):
         oci = FakeOci()
         oci.add_list(
             "network vcn list",
@@ -929,11 +929,6 @@ class CleanupTestCase(unittest.TestCase):
             ],
         )
         cleaner = self.make_cleaner(execute=True, oci=oci)
-        cleaner.manifest.record_action(
-            f"subnet:{HOME_REGION}:blocked-subnet",
-            "Old completed subnet deletion",
-            "completed",
-        )
         cleaner.extra_candidates = [
             extra_candidate(
                 candidate_id=f"extra:unsupported-vnic:{HOME_REGION}:vnic",
@@ -946,10 +941,16 @@ class CleanupTestCase(unittest.TestCase):
 
         cleaner.cleanup_network(context(), HOME_REGION)
 
-        subnet_action = cleaner.manifest.data["actions"][
-            f"subnet:{HOME_REGION}:blocked-subnet"
-        ]
+        subnet_action = next(
+            action
+            for action in cleaner.planned
+            if action["id"] == f"subnet:{HOME_REGION}:blocked-subnet"
+        )
         self.assertEqual("blocked", subnet_action["status"])
+        self.assertEqual("blocked-subnet", subnet_action["resource_id"])
+        self.assertEqual(HOME_REGION, subnet_action["region"])
+        self.assertIsNone(subnet_action["error_code"])
+        self.assertIn("Preserve Quickstart subnet", subnet_action["deletion_message"])
         self.assertFalse(
             any(
                 "network route-table list" in " ".join(call)
@@ -962,6 +963,25 @@ class CleanupTestCase(unittest.TestCase):
                 and action["status"] == "blocked"
                 for action in cleaner.planned
             )
+        )
+        self.assertEqual(2, len(cleaner.failures))
+        subnet_failure, dependents_failure = cleaner.failures
+        self.assertEqual(
+            {
+                "message": subnet_action["description"],
+                "resource_id": "blocked-subnet",
+                "region": HOME_REGION,
+                "error_code": None,
+                "deletion_message": subnet_action["description"],
+            },
+            subnet_failure,
+        )
+        self.assertEqual("", dependents_failure["resource_id"])
+        self.assertEqual(HOME_REGION, dependents_failure["region"])
+        self.assertIsNone(dependents_failure["error_code"])
+        self.assertIn(
+            "Preserve route tables, gateways, and VCN",
+            dependents_failure["deletion_message"],
         )
 
     def test_network_deletes_route_tables_before_owned_gateways(self):


### PR DESCRIPTION
## Summary
- delete owned subnets, route rules and tables, gateways, and VCNs in dependency order
- discover nested VNIC and network blockers and require explicit confirmation before destructive cleanup
- preserve customer-owned resources and stop parent deletion when dependencies remain

## Stack
- Depends on https://github.com/DataDog/oracle-cloud-integration/pull/165
- For context on how this package works - [README](https://github.com/DataDog/oracle-cloud-integration/blob/3fa9a804a2526815d31fae7ac37db982132c75e0/oci-integration-cleanup/README.md)

## Test plan
- [x] `python3 -m unittest discover -s oci-integration-cleanup/tests -p 'test_*.py' -v` (26 tests)