### PR TITLE
Clean up forwarding services and storage

### DIFF
--- a/oci-integration-cleanup/integration_cleanup.py
+++ b/oci-integration-cleanup/integration_cleanup.py
@@ -27,6 +27,7 @@ from oci_cleanup.base import CleanupBase
 from oci_cleanup.discovery import DiscoveryMixin
 from oci_cleanup.domains.extras import ExtrasMixin
 from oci_cleanup.domains.network import NetworkMixin
+from oci_cleanup.domains.services import ServicesMixin
 from oci_cleanup.engine import EngineMixin
 from oci_cleanup.region import RegionMixin
 
@@ -38,10 +39,11 @@ class QuickstartCleanup(
     DiscoveryMixin,
     ExtrasMixin,
     RegionMixin,
+    ServicesMixin,
     NetworkMixin,
     CleanupBase,
 ):
-    """Discover and remove Quickstart networking resources."""
+    """Remove Quickstart forwarding services, storage, and networking."""
 
 
 def _parse_bool(value: str) -> bool:

--- a/oci-integration-cleanup/oci_cleanup/discovery.py
+++ b/oci-integration-cleanup/oci_cleanup/discovery.py
@@ -13,11 +13,13 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
-from .constants import AUTO_COMPARTMENT_NAME, LOGGER
+from .constants import AUTO_COMPARTMENT_NAME, FUNCTION_APP_NAME, LOGGER
 from .errors import CleanupError
 from .models import CleanupContext
 from .resources import (
     data_items,
+    exact_owned,
+    is_deleted_or_deleting,
     is_owned,
     resource_compartment,
     resource_id,
@@ -28,6 +30,61 @@ from .resources import (
 
 class DiscoveryMixin:
     """Discover and validate the cleanup context."""
+
+    @staticmethod
+    def _is_managed_function(
+        context: CleanupContext, region: str, function_id: str
+    ) -> bool:
+        return any(
+            resource.get("_region") == region
+            and resource_compartment(resource) == context.compartment_id
+            and resource_id(resource) == function_id
+            and function_id.startswith("ocid1.fnfunc.")
+            for resource in context.managed_resources
+        )
+
+    def _owned_function_applications(
+        self, context: CleanupContext, region: str
+    ) -> list[tuple[dict[str, Any], list[dict[str, Any]]]]:
+        applications = self._list_region(
+            region,
+            [
+                "fn",
+                "application",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+            ],
+        )
+        discovered = []
+        for application in applications:
+            if not exact_owned(
+                application,
+                expected_names={FUNCTION_APP_NAME},
+                compartment_id=context.compartment_id,
+            ):
+                continue
+            functions = self._list_region(
+                region,
+                [
+                    "fn",
+                    "function",
+                    "list",
+                    "--application-id",
+                    resource_id(application),
+                ],
+            )
+            discovered.append(
+                (
+                    application,
+                    [
+                        function
+                        for function in functions
+                        if not is_deleted_or_deleting(function)
+                    ],
+                )
+            )
+        return discovered
 
     def _discover_region_tags(
         self, region: str

--- a/oci-integration-cleanup/oci_cleanup/domains/extras.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/extras.py
@@ -83,6 +83,102 @@ class ExtrasMixin:
             details=details or {},
         )
 
+    def _discover_function_extras(
+        self, context: CleanupContext, region: str
+    ) -> list[ExtraResourceCandidate]:
+        candidates: list[ExtraResourceCandidate] = []
+        for application, functions in self._owned_function_applications(
+            context, region
+        ):
+            application_id = resource_id(application)
+            for function in functions:
+                function_id = resource_id(function)
+                marker_proven = defined_marker(function) or self._is_managed_function(
+                    context, region, function_id
+                )
+                if marker_proven or resource_name(function) in FUNCTION_NAMES:
+                    continue
+                candidates.append(
+                    self._extra_candidate(
+                        kind="function",
+                        resource=function,
+                        region=region,
+                        container_id=application_id,
+                        container_name=FUNCTION_APP_NAME,
+                        impact=(
+                            "Deleting it is required before the owned Functions "
+                            "application can be deleted."
+                        ),
+                        command=[
+                            "--region",
+                            region,
+                            "fn",
+                            "function",
+                            "delete",
+                            "--function-id",
+                            function_id,
+                            "--force",
+                            "--wait-for-state",
+                            "DELETED",
+                        ],
+                    )
+                )
+        return candidates
+
+    @staticmethod
+    def _is_managed_function(
+        context: CleanupContext, region: str, function_id: str
+    ) -> bool:
+        return any(
+            resource.get("_region") == region
+            and resource_compartment(resource) == context.compartment_id
+            and resource_id(resource) == function_id
+            and function_id.startswith("ocid1.fnfunc.")
+            for resource in context.managed_resources
+        )
+
+    def _owned_function_applications(
+        self, context: CleanupContext, region: str
+    ) -> list[tuple[dict[str, Any], list[dict[str, Any]]]]:
+        applications = self._list_region(
+            region,
+            [
+                "fn",
+                "application",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+            ],
+        )
+        discovered = []
+        for application in applications:
+            if not exact_owned(
+                application,
+                expected_names={FUNCTION_APP_NAME},
+                compartment_id=context.compartment_id,
+            ):
+                continue
+            functions = self._list_region(
+                region,
+                [
+                    "fn",
+                    "function",
+                    "list",
+                    "--application-id",
+                    resource_id(application),
+                ],
+            )
+            discovered.append(
+                (
+                    application,
+                    [
+                        function
+                        for function in functions
+                        if not is_deleted_or_deleting(function)
+                    ],
+                )
+            )
+        return discovered
 
     def _compute_compartment_ids(self, context: CleanupContext) -> list[str]:
         if self._accessible_compartment_ids is not None:
@@ -560,7 +656,10 @@ class ExtrasMixin:
         LOGGER.info("Discovering extra resources inside owned Datadog containers")
         candidates: dict[str, ExtraResourceCandidate] = {}
         for region in context.regions:
-            discovered = self._discover_network_extras(context, region)
+            discovered = [
+                *self._discover_function_extras(context, region),
+                *self._discover_network_extras(context, region),
+            ]
             for candidate in discovered:
                 candidates[candidate.candidate_id] = candidate
         return sorted(

--- a/oci-integration-cleanup/oci_cleanup/domains/extras.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/extras.py
@@ -125,61 +125,6 @@ class ExtrasMixin:
                 )
         return candidates
 
-    @staticmethod
-    def _is_managed_function(
-        context: CleanupContext, region: str, function_id: str
-    ) -> bool:
-        return any(
-            resource.get("_region") == region
-            and resource_compartment(resource) == context.compartment_id
-            and resource_id(resource) == function_id
-            and function_id.startswith("ocid1.fnfunc.")
-            for resource in context.managed_resources
-        )
-
-    def _owned_function_applications(
-        self, context: CleanupContext, region: str
-    ) -> list[tuple[dict[str, Any], list[dict[str, Any]]]]:
-        applications = self._list_region(
-            region,
-            [
-                "fn",
-                "application",
-                "list",
-                "--compartment-id",
-                context.compartment_id,
-            ],
-        )
-        discovered = []
-        for application in applications:
-            if not exact_owned(
-                application,
-                expected_names={FUNCTION_APP_NAME},
-                compartment_id=context.compartment_id,
-            ):
-                continue
-            functions = self._list_region(
-                region,
-                [
-                    "fn",
-                    "function",
-                    "list",
-                    "--application-id",
-                    resource_id(application),
-                ],
-            )
-            discovered.append(
-                (
-                    application,
-                    [
-                        function
-                        for function in functions
-                        if not is_deleted_or_deleting(function)
-                    ],
-                )
-            )
-        return discovered
-
     def _compute_compartment_ids(self, context: CleanupContext) -> list[str]:
         if self._accessible_compartment_ids is not None:
             return self._accessible_compartment_ids

--- a/oci-integration-cleanup/oci_cleanup/domains/services.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/services.py
@@ -1,0 +1,344 @@
+"""Responsibility: clean connectors, event rules, streams, buckets, and functions.
+
+Safety boundary: retains service-specific names, ownership evidence, waiters, and dependencies.
+Cleanup sequence role: removes forwarding services before network and KMS teardown.
+
+``ServicesMixin`` removes connector hubs, event rules, streams, backfill buckets,
+functions, and their application using each API's required lookup and delete shape.
+Its methods keep producer/consumer and child/application ordering explicit.
+"""
+
+from __future__ import annotations
+
+from ..constants import BACKFILL_BUCKET_NAMES, FUNCTION_APP_NAME, FUNCTION_NAMES
+from ..errors import CleanupError
+from ..models import CleanupContext
+from ..resources import (
+    defined_marker,
+    is_owned,
+    resource_compartment,
+    resource_id,
+    resource_name,
+)
+
+SUPPORTED_MANAGED_RESOURCE_PREFIXES = (
+    # Buckets, functions, and connectors are recognized here but reconciled by
+    # their service-specific cleanup paths.
+    "ocid1.bucket.",
+    "ocid1.eventrule.",
+    "ocid1.fnfunc.",
+    "ocid1.serviceconnector.",
+    "ocid1.stream.",
+)
+
+
+class ServicesMixin:
+    """Remove validated forwarding services and storage resources."""
+
+    def cleanup_connectors_events_streams(
+        self, context: CleanupContext, region: str
+    ) -> None:
+        connectors = self._list_region(
+            region,
+            [
+                "sch",
+                "service-connector",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+            ],
+        )
+        for connector in connectors:
+            if not (is_owned(connector) or defined_marker(connector)):
+                continue
+            connector_id = resource_id(connector)
+            self.action(
+                f"connector:{region}:{connector_id}",
+                f"Delete Datadog-owned service connector {resource_name(connector)}",
+                command=[
+                    "--region",
+                    region,
+                    "sch",
+                    "service-connector",
+                    "delete",
+                    "--service-connector-id",
+                    connector_id,
+                    "--force",
+                    "--wait-for-state",
+                    "SUCCEEDED",
+                    "--wait-for-state",
+                    "FAILED",
+                ],
+            )
+
+        rules = self._list_region(
+            region,
+            [
+                "events",
+                "rule",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+            ],
+        )
+        deleted_rule_ids: set[str] = set()
+        for rule in rules:
+            if not (is_owned(rule) or defined_marker(rule)):
+                continue
+            rule_id = resource_id(rule)
+            deleted_rule_ids.add(rule_id)
+            self.action(
+                f"event-rule:{region}:{rule_id}",
+                f"Delete Datadog-owned event rule {resource_name(rule)}",
+                command=[
+                    "--region",
+                    region,
+                    "events",
+                    "rule",
+                    "delete",
+                    "--rule-id",
+                    rule_id,
+                    "--force",
+                    "--wait-for-state",
+                    "DELETED",
+                ],
+            )
+
+        streams = self._list_region(
+            region,
+            [
+                "streaming",
+                "admin",
+                "stream",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+            ],
+        )
+        deleted_stream_ids: set[str] = set()
+        for stream in streams:
+            if not (is_owned(stream) or defined_marker(stream)):
+                continue
+            stream_id = resource_id(stream)
+            deleted_stream_ids.add(stream_id)
+            self.action(
+                f"stream:{region}:{stream_id}",
+                f"Delete Datadog-owned stream {resource_name(stream)}",
+                command=[
+                    "--region",
+                    region,
+                    "streaming",
+                    "admin",
+                    "stream",
+                    "delete",
+                    "--stream-id",
+                    stream_id,
+                    "--force",
+                    "--wait-for-state",
+                    "SUCCEEDED",
+                ],
+            )
+
+        # Event rules may live outside the Datadog resource compartment because
+        # their IAM grant is tenancy-scoped. Resource Search provides the only
+        # tenancy-wide marker lookup, so delete marker-proven rules and streams
+        # that the compartment-scoped service lists did not return.
+        for resource in context.managed_resources:
+            if resource.get("_region") != region or not defined_marker(resource):
+                continue
+            identifier = resource_id(resource)
+            if identifier.startswith("ocid1.eventrule.") and identifier not in deleted_rule_ids:
+                self.action(
+                    f"event-rule:{region}:{identifier}",
+                    f"Delete marker-proven Datadog event rule {resource_name(resource)}",
+                    command=[
+                        "--region",
+                        region,
+                        "events",
+                        "rule",
+                        "delete",
+                        "--rule-id",
+                        identifier,
+                        "--force",
+                        "--wait-for-state",
+                        "DELETED",
+                    ],
+                )
+            elif identifier.startswith("ocid1.stream.") and identifier not in deleted_stream_ids:
+                self.action(
+                    f"stream:{region}:{identifier}",
+                    f"Delete marker-proven Datadog stream {resource_name(resource)}",
+                    command=[
+                        "--region",
+                        region,
+                        "streaming",
+                        "admin",
+                        "stream",
+                        "delete",
+                        "--stream-id",
+                        identifier,
+                        "--force",
+                        "--wait-for-state",
+                        "DELETED",
+                    ],
+                )
+            elif not identifier.startswith(SUPPORTED_MANAGED_RESOURCE_PREFIXES):
+                self.failures.append(
+                    "DatadogManaged.marker is attached to unsupported resource "
+                    f"{identifier or resource_name(resource)} in {region}; "
+                    "manual review required"
+                )
+
+    def cleanup_buckets(self, context: CleanupContext, region: str) -> None:
+        namespace_payload = self.oci.run(
+            ["--region", region, "os", "ns", "get"], attempts=2
+        )
+        namespace = str(namespace_payload.get("data", ""))
+        if not namespace:
+            raise CleanupError(f"Could not resolve Object Storage namespace in {region}")
+        listed_buckets = self._list_region(
+            region,
+            [
+                "os",
+                "bucket",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+                "--namespace-name",
+                namespace,
+            ],
+        )
+        buckets_by_name = {
+            resource_name(bucket): bucket
+            for bucket in listed_buckets
+            if (
+                (is_owned(bucket) or defined_marker(bucket))
+                and resource_name(bucket) in BACKFILL_BUCKET_NAMES
+            )
+        }
+        # Marker-proven buckets can live outside the target compartment. Bucket
+        # names are unique within an Object Storage namespace, so Resource Search
+        # supplies enough information to reconcile them with the regional list.
+        for resource in context.managed_resources:
+            name = resource_name(resource)
+            if (
+                resource.get("_region") == region
+                and defined_marker(resource)
+                and resource_id(resource).startswith("ocid1.bucket.")
+                and name in BACKFILL_BUCKET_NAMES
+            ):
+                buckets_by_name.setdefault(name, resource)
+
+        for bucket in buckets_by_name.values():
+            name = resource_name(bucket)
+            self.action(
+                f"bucket-versions:{region}:{name}",
+                f"Delete all object versions from Datadog-owned bucket {name}",
+                command=[
+                    "--region",
+                    region,
+                    "os",
+                    "object",
+                    "bulk-delete-versions",
+                    "--namespace-name",
+                    namespace,
+                    "--bucket-name",
+                    name,
+                    "--force",
+                ],
+            )
+            self.action(
+                f"bucket:{region}:{name}",
+                f"Empty and delete Datadog-owned bucket {name}",
+                command=[
+                    "--region",
+                    region,
+                    "os",
+                    "bucket",
+                    "delete",
+                    "--namespace-name",
+                    namespace,
+                    "--bucket-name",
+                    name,
+                    "--empty",
+                    "--force",
+                ],
+            )
+
+    def cleanup_functions(self, context: CleanupContext, region: str) -> None:
+        self._delete_approved_extras(region=region, kinds={"function"})
+        handled_function_ids: set[str] = set()
+        for application, functions in self._owned_function_applications(
+            context, region
+        ):
+            application_id = resource_id(application)
+            for function in functions:
+                name = resource_name(function)
+                function_id = resource_id(function)
+                marker_proven = defined_marker(function) or self._is_managed_function(
+                    context, region, function_id
+                )
+                if not marker_proven and name not in FUNCTION_NAMES:
+                    continue
+                handled_function_ids.add(function_id)
+                self.action(
+                    f"function:{region}:{function_id}",
+                    f"Delete forwarding function {name}",
+                    command=[
+                        "--region",
+                        region,
+                        "fn",
+                        "function",
+                        "delete",
+                        "--function-id",
+                        function_id,
+                        "--force",
+                        "--wait-for-state",
+                        "DELETED",
+                    ],
+                )
+            if self._has_unapproved_extra(
+                region=region, container_id=application_id
+            ):
+                self.planned.append(
+                    {
+                        "id": f"function-app:{region}:{application_id}",
+                        "description": (
+                            f"Preserve functions application {FUNCTION_APP_NAME} "
+                            "because an extra function was not approved"
+                        ),
+                        "status": "blocked",
+                    }
+                )
+                continue
+            self.action(
+                f"function-app:{region}:{application_id}",
+                f"Delete functions application {FUNCTION_APP_NAME}",
+                command=[
+                    "--region",
+                    region,
+                    "fn",
+                    "application",
+                    "delete",
+                    "--application-id",
+                    application_id,
+                    "--force",
+                    "--wait-for-state",
+                    "DELETED",
+                ],
+            )
+        for resource in context.managed_resources:
+            identifier = resource_id(resource)
+            if (
+                resource.get("_region") == region
+                and resource_compartment(resource) == context.compartment_id
+                and identifier.startswith("ocid1.fnfunc.")
+                and identifier not in handled_function_ids
+            ):
+                self.failures.append(
+                    "Marker-proven Datadog function was not found under the "
+                    f"owned {FUNCTION_APP_NAME} application: {identifier} in "
+                    f"{region}; manual review required"
+                )
+
+

--- a/oci-integration-cleanup/oci_cleanup/domains/services.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/services.py
@@ -183,10 +183,16 @@ class ServicesMixin:
                     ],
                 )
             elif not identifier.startswith(SUPPORTED_MANAGED_RESOURCE_PREFIXES):
-                self.failures.append(
+                message = (
                     "DatadogManaged.marker is attached to unsupported resource "
                     f"{identifier or resource_name(resource)} in {region}; "
                     "manual review required"
+                )
+                self._record_failure(
+                    message,
+                    resource_id=identifier,
+                    region=region,
+                    deletion_message=message,
                 )
 
     def cleanup_buckets(self, context: CleanupContext, region: str) -> None:
@@ -335,10 +341,14 @@ class ServicesMixin:
                 and identifier.startswith("ocid1.fnfunc.")
                 and identifier not in handled_function_ids
             ):
-                self.failures.append(
+                message = (
                     "Marker-proven Datadog function was not found under the "
                     f"owned {FUNCTION_APP_NAME} application: {identifier} in "
                     f"{region}; manual review required"
                 )
-
-
+                self._record_failure(
+                    message,
+                    resource_id=identifier,
+                    region=region,
+                    deletion_message=message,
+                )

--- a/oci-integration-cleanup/oci_cleanup/region.py
+++ b/oci-integration-cleanup/oci_cleanup/region.py
@@ -10,7 +10,13 @@ class RegionMixin:
     """Coordinate cleanup and failure isolation for each region."""
 
     def cleanup_region(self, context: CleanupContext, region: str) -> None:
-        LOGGER.info("Cleaning Quickstart networking in %s", region)
+        LOGGER.info("[%s] Checking connectors, event rules, and streams", region)
+        self.cleanup_connectors_events_streams(context, region)
+        LOGGER.info("[%s] Checking Object Storage buckets", region)
+        self.cleanup_buckets(context, region)
+        LOGGER.info("[%s] Checking forwarding functions", region)
+        self.cleanup_functions(context, region)
+        LOGGER.info("[%s] Checking Quickstart networking", region)
         self.cleanup_network(context, region)
 
 

--- a/oci-integration-cleanup/tests/test_integration_cleanup.py
+++ b/oci-integration-cleanup/tests/test_integration_cleanup.py
@@ -668,6 +668,173 @@ class CleanupTestCase(unittest.TestCase):
             self.assertEqual(value, cleaner.failures[0][key])
             self.assertEqual(value, cleaner.planned[0][key])
 
+    def test_functions_cleanup_preserves_customer_application(self):
+        oci = FakeOci()
+        oci.add_list(
+            "fn application list",
+            [
+                owned(
+                    {
+                        "id": "dd-app",
+                        "display-name": cleanup.FUNCTION_APP_NAME,
+                        "compartment-id": COMPARTMENT,
+                    }
+                ),
+                {
+                    "id": "customer-app",
+                    "display-name": cleanup.FUNCTION_APP_NAME,
+                    "compartment-id": COMPARTMENT,
+                },
+            ],
+        )
+        oci.add_list(
+            "fn function list",
+            [
+                owned(
+                    {
+                        "id": "logs",
+                        "display-name": "dd-logs-forwarder",
+                    }
+                ),
+                {
+                    "id": "events",
+                    "display-name": "dd-events-forwarder",
+                    "defined-tags": {
+                        "DatadogManaged": {"marker": "true"}
+                    },
+                },
+                {
+                    "id": "events-suffixed",
+                    "display-name": "dd-events-forwarder-309",
+                    "defined-tags": {
+                        "DatadogManaged": {"marker": "true"}
+                    },
+                },
+                {
+                    "id": "ocid1.fnfunc.oc1..search-owned",
+                    "display-name": "dd-metrics-forwarder",
+                },
+                {"id": "untagged-metrics", "display-name": "dd-metrics-forwarder"},
+                {
+                    "id": "deleting-logs",
+                    "display-name": "dd-logs-forwarder",
+                    "lifecycle-state": "DELETING",
+                },
+            ],
+        )
+        cleaner = self.make_cleaner(oci=oci)
+        cleaner.cleanup_functions(
+            context(
+                tagged_resources=[
+                    {
+                        "identifier": "ocid1.fnfunc.oc1..search-owned",
+                        "display-name": "dd-metrics-forwarder",
+                        "compartment-id": COMPARTMENT,
+                        "_region": HOME_REGION,
+                    }
+                ],
+                managed_resources=[
+                    {
+                        "identifier": "events",
+                        "display-name": "dd-events-forwarder",
+                        "compartment-id": COMPARTMENT,
+                        "defined-tags": {
+                            "DatadogManaged": {"marker": "true"}
+                        },
+                        "_region": HOME_REGION,
+                    },
+                    {
+                        "identifier": "events-suffixed",
+                        "display-name": "dd-events-forwarder-309",
+                        "compartment-id": COMPARTMENT,
+                        "defined-tags": {
+                            "DatadogManaged": {"marker": "true"}
+                        },
+                        "_region": HOME_REGION,
+                    }
+                ]
+            ),
+            HOME_REGION,
+        )
+        action_ids = {action["id"] for action in cleaner.planned}
+        self.assertIn(f"function:{HOME_REGION}:logs", action_ids)
+        self.assertIn(f"function:{HOME_REGION}:events", action_ids)
+        self.assertIn(f"function:{HOME_REGION}:events-suffixed", action_ids)
+        self.assertIn(
+            f"function:{HOME_REGION}:ocid1.fnfunc.oc1..search-owned",
+            action_ids,
+        )
+        self.assertIn(
+            f"function:{HOME_REGION}:untagged-metrics",
+            action_ids,
+        )
+        self.assertNotIn(f"function:{HOME_REGION}:deleting-logs", action_ids)
+        self.assertIn(f"function-app:{HOME_REGION}:dd-app", action_ids)
+        self.assertFalse(any("customer-app" in action_id for action_id in action_ids))
+
+    def test_discovers_unknown_function_inside_owned_application(self):
+        oci = FakeOci()
+        oci.add_list(
+            "fn application list",
+            [
+                owned(
+                    {
+                        "id": "dd-app",
+                        "display-name": cleanup.FUNCTION_APP_NAME,
+                        "compartment-id": COMPARTMENT,
+                    }
+                )
+            ],
+        )
+        oci.add_list(
+            "fn function list",
+            [
+                {"id": "known", "display-name": "dd-logs-forwarder"},
+                {"id": "extra", "display-name": "customer-function"},
+                {
+                    "id": "deleting-extra",
+                    "display-name": "customer-function",
+                    "lifecycle-state": "DELETING",
+                },
+            ],
+        )
+
+        candidates = self.make_cleaner(oci=oci)._discover_function_extras(
+            context(), HOME_REGION
+        )
+
+        self.assertEqual(["extra"], [candidate.resource_id for candidate in candidates])
+        self.assertIn("fn function delete", " ".join(candidates[0].command or ()))
+
+    def test_declined_extra_function_blocks_application_deletion(self):
+        oci = FakeOci()
+        oci.add_list(
+            "fn application list",
+            [
+                owned(
+                    {
+                        "id": "dd-app",
+                        "display-name": cleanup.FUNCTION_APP_NAME,
+                        "compartment-id": COMPARTMENT,
+                    }
+                )
+            ],
+        )
+        oci.add_list("fn function list", [])
+        cleaner = self.make_cleaner(oci=oci)
+        cleaner.extra_candidates = [
+            extra_candidate(container_id="dd-app")
+        ]
+
+        cleaner.cleanup_functions(context(), HOME_REGION)
+
+        application = next(
+            action
+            for action in cleaner.planned
+            if action["id"] == f"function-app:{HOME_REGION}:dd-app"
+        )
+        self.assertEqual("blocked", application["status"])
+
     def test_discovers_secondary_and_primary_compute_vnic_actions(self):
         oci = FakeOci()
         oci.add_run(
@@ -845,6 +1012,67 @@ class CleanupTestCase(unittest.TestCase):
         self.assertTrue(candidate.requires_compute_confirmation)
         self.assertIn("terminate", candidate.command or ())
 
+    def test_bucket_cleanup_deletes_only_proven_backfill_buckets(self):
+        oci = FakeOci()
+        oci.add_run("os ns get", {"data": "test-namespace"})
+        oci.add_list(
+            "os bucket list",
+            [
+                {
+                    "name": "dd-events-backfill",
+                    "defined-tags": {
+                        "DatadogManaged": {"marker": "true"}
+                    },
+                },
+                owned({"name": "dd-logs-backfill"}),
+                owned({"name": "dd-customer-data"}),
+                {"name": "dd-metrics-backfill"},
+            ],
+        )
+        cleaner = self.make_cleaner(oci=oci)
+        cleaner.cleanup_buckets(context(), HOME_REGION)
+
+        action_ids = {action["id"] for action in cleaner.planned}
+        self.assertIn(
+            f"bucket:{HOME_REGION}:dd-events-backfill",
+            action_ids,
+        )
+        self.assertIn(
+            f"bucket:{HOME_REGION}:dd-logs-backfill",
+            action_ids,
+        )
+        self.assertNotIn(
+            f"bucket:{HOME_REGION}:dd-customer-data",
+            action_ids,
+        )
+        self.assertNotIn(
+            f"bucket:{HOME_REGION}:dd-metrics-backfill",
+            action_ids,
+        )
+
+    def test_bucket_cleanup_reconciles_marker_proven_bucket_outside_compartment(self):
+        oci = FakeOci()
+        oci.add_run("os ns get", {"data": "test-namespace"})
+        oci.add_list("os bucket list", [])
+        bucket = {
+            "identifier": "ocid1.bucket.oc1..datadog",
+            "display-name": "dd-events-backfill",
+            "compartment-id": "ocid1.compartment.oc1..workload",
+            "definedTags": {"DatadogManaged": {"marker": "true"}},
+            "_region": HOME_REGION,
+        }
+
+        cleaner = self.make_cleaner(oci=oci)
+        cleaner.cleanup_buckets(
+            context(managed_resources=[bucket]),
+            HOME_REGION,
+        )
+
+        action_ids = {action["id"] for action in cleaner.planned}
+        self.assertIn(
+            f"bucket:{HOME_REGION}:dd-events-backfill",
+            action_ids,
+        )
     def test_compartment_inventory_failure_is_not_cached(self):
         cleaner = self.make_cleaner()
         transient_error = cleanup.CommandError(
@@ -1074,6 +1302,73 @@ class CleanupTestCase(unittest.TestCase):
             '"network-entity-id":"nat-gateway"',
             commands[update_index],
         )
+
+    def test_connector_delete_waits_for_work_request_success(self):
+        oci = FakeOci()
+        oci.add_list(
+            "sch service-connector list",
+            [
+                owned(
+                    {
+                        "id": "connector",
+                        "display-name": "Datadog connector",
+                    }
+                )
+            ],
+        )
+        oci.add_list("events rule list", [])
+        oci.add_list("streaming admin stream list", [])
+        cleaner = self.make_cleaner(oci=oci, execute=True)
+
+        cleaner.cleanup_connectors_events_streams(context(), HOME_REGION)
+
+        delete = next(
+            call
+            for call in oci.run_calls
+            if "service-connector" in call and "delete" in call
+        )
+        self.assertIn("SUCCEEDED", delete)
+        self.assertIn("FAILED", delete)
+        self.assertNotIn("DELETED", delete)
+
+    def test_marker_proven_event_rule_outside_target_compartment_is_deleted(self):
+        oci = FakeOci()
+        oci.add_list("sch service-connector list", [])
+        oci.add_list("events rule list", [])
+        oci.add_list("streaming admin stream list", [])
+        rule = {
+            "identifier": "ocid1.eventrule.oc1..datadog",
+            "display-name": "Datadog event forwarding",
+            "compartment-id": "ocid1.compartment.oc1..workload",
+            "definedTags": {"DatadogManaged": {"marker": "true"}},
+            "_region": HOME_REGION,
+        }
+        stream = {
+            "identifier": "ocid1.stream.oc1..datadog",
+            "display-name": "Datadog event stream",
+            "compartment-id": "ocid1.compartment.oc1..workload",
+            "definedTags": {"DatadogManaged": {"marker": "true"}},
+            "_region": HOME_REGION,
+        }
+        cleaner = self.make_cleaner(oci=oci, execute=True)
+        cleaner.cleanup_connectors_events_streams(
+            context(managed_resources=[rule, stream]), HOME_REGION
+        )
+        self.assertTrue(
+            any(
+                action["id"]
+                == f"event-rule:{HOME_REGION}:ocid1.eventrule.oc1..datadog"
+                for action in cleaner.planned
+            )
+        )
+        event_delete = next(
+            call for call in oci.run_calls if "events" in call and "delete" in call
+        )
+        stream_delete = next(
+            call for call in oci.run_calls if "streaming" in call and "delete" in call
+        )
+        self.assertEqual("DELETED", event_delete[-1])
+        self.assertEqual("DELETED", stream_delete[-1])
 
     def test_run_cleans_regions_concurrently(self):
         cleaner = self.make_cleaner(


### PR DESCRIPTION
## Summary
- remove Datadog service connectors, event rules, streams, Functions resources, and backfill buckets
- verify ownership before deletion and preserve customer applications and buckets
- require approval for unexpected functions that block application deletion

## Stack
- Depends on https://github.com/DataDog/oracle-cloud-integration/pull/166
- For context on how this package works - [README](https://github.com/DataDog/oracle-cloud-integration/blob/3fa9a804a2526815d31fae7ac37db982132c75e0/oci-integration-cleanup/README.md)

## Test plan
- [x] `python3 -m unittest discover -s oci-integration-cleanup/tests -p 'test_*.py' -v` (31 tests)