### PR TITLE
Schedule KMS resources for deletion

### DIFF
--- a/oci-integration-cleanup/integration_cleanup.py
+++ b/oci-integration-cleanup/integration_cleanup.py
@@ -26,6 +26,7 @@ from oci_cleanup import __all__ as package_api
 from oci_cleanup.base import CleanupBase
 from oci_cleanup.discovery import DiscoveryMixin
 from oci_cleanup.domains.extras import ExtrasMixin
+from oci_cleanup.domains.kms import KmsMixin
 from oci_cleanup.domains.network import NetworkMixin
 from oci_cleanup.domains.services import ServicesMixin
 from oci_cleanup.engine import EngineMixin
@@ -41,9 +42,10 @@ class QuickstartCleanup(
     RegionMixin,
     ServicesMixin,
     NetworkMixin,
+    KmsMixin,
     CleanupBase,
 ):
-    """Remove Quickstart forwarding services, storage, and networking."""
+    """Remove Quickstart resources and schedule KMS deletion."""
 
 
 def _parse_bool(value: str) -> bool:

--- a/oci-integration-cleanup/oci_cleanup/domains/kms.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/kms.py
@@ -20,7 +20,12 @@ from ..constants import (
     VAULT_NAME,
 )
 from ..models import CleanupContext
-from ..resources import exact_owned, lifecycle_state, resource_id
+from ..resources import (
+    exact_owned,
+    lifecycle_state,
+    resource_id,
+    resource_management_endpoint,
+)
 
 
 class KmsMixin:
@@ -106,11 +111,7 @@ class KmsMixin:
                 self.kms_pending = True
                 continue
             vault_id = resource_id(vault)
-            endpoint = str(
-                vault.get("management-endpoint")
-                or vault.get("management_endpoint")
-                or ""
-            )
+            endpoint = resource_management_endpoint(vault)
             if not endpoint:
                 self.failures.append(
                     f"Owned vault {vault_id} has no management endpoint"

--- a/oci-integration-cleanup/oci_cleanup/domains/kms.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/kms.py
@@ -1,0 +1,185 @@
+"""Responsibility: schedule secret, key, and vault deletion.
+
+Safety boundary: enforces exact names, ownership, compartment, and OCI minimum delays.
+Cleanup sequence role: runs at the end of each regional cleanup sequence.
+
+``KmsMixin`` schedules secret, master-key, and vault deletion. Stable deletion timestamps 
+are stored in the manifest so retries reuse the original schedule and preserve the required 
+child-before-parent order.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from ..constants import (
+    KEY_NAME,
+    KMS_DELETION_DELAY,
+    SECRET_DELETION_DELAY,
+    SECRET_NAME,
+    VAULT_NAME,
+)
+from ..models import CleanupContext
+from ..resources import exact_owned, lifecycle_state, resource_id
+
+
+class KmsMixin:
+    """Schedule deletion of Quickstart secrets, keys, and vaults."""
+
+    def _deletion_time(self, manifest_key: str, delay: dt.timedelta) -> str:
+        with self.manifest.lock:
+            existing = self.manifest.data["context"].get(manifest_key)
+            if existing:
+                return str(existing)
+            value = (
+                dt.datetime.now(dt.timezone.utc)
+                + delay
+            ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+            self.manifest.data["context"][manifest_key] = value
+            return value
+
+    def cleanup_kms(self, context: CleanupContext, region: str) -> None:
+        secret_deletion_time = self._deletion_time(
+            "secret_deletion_time", SECRET_DELETION_DELAY
+        )
+        kms_deletion_time = self._deletion_time(
+            "kms_deletion_time", KMS_DELETION_DELAY
+        )
+        secrets = self._list_region(
+            region,
+            [
+                "vault",
+                "secret",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+            ],
+        )
+        for secret in secrets:
+            if not exact_owned(
+                secret,
+                expected_names={SECRET_NAME},
+                compartment_id=context.compartment_id,
+            ):
+                continue
+            if lifecycle_state(secret) == "PENDING_DELETION":
+                self.kms_pending = True
+                continue
+            identifier = resource_id(secret)
+            self.action(
+                f"secret:{region}:{identifier}",
+                f"Schedule deletion of {SECRET_NAME} in {region}",
+                command=[
+                    "--region",
+                    region,
+                    "vault",
+                    "secret",
+                    "schedule-secret-deletion",
+                    "--secret-id",
+                    identifier,
+                    "--time-of-deletion",
+                    secret_deletion_time,
+                ],
+                details={"deletion_time": secret_deletion_time},
+            )
+            self.kms_pending = True
+
+        vaults = self._list_region(
+            region,
+            [
+                "kms",
+                "management",
+                "vault",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+            ],
+        )
+        for vault in vaults:
+            if not exact_owned(
+                vault,
+                expected_names={VAULT_NAME},
+                compartment_id=context.compartment_id,
+            ):
+                continue
+            if lifecycle_state(vault) == "PENDING_DELETION":
+                self.kms_pending = True
+                continue
+            vault_id = resource_id(vault)
+            endpoint = str(
+                vault.get("management-endpoint")
+                or vault.get("management_endpoint")
+                or ""
+            )
+            if not endpoint:
+                self.failures.append(
+                    f"Owned vault {vault_id} has no management endpoint"
+                )
+                continue
+            keys = self.oci.list(
+                [
+                    "--region",
+                    region,
+                    "kms",
+                    "management",
+                    "key",
+                    "list",
+                    "--endpoint",
+                    endpoint,
+                    "--compartment-id",
+                    context.compartment_id,
+                ]
+            )
+            for key in keys:
+                if not exact_owned(
+                    key,
+                    expected_names={KEY_NAME},
+                    compartment_id=context.compartment_id,
+                ):
+                    continue
+                if lifecycle_state(key) == "PENDING_DELETION":
+                    self.kms_pending = True
+                    continue
+                key_id = resource_id(key)
+                self.action(
+                    f"kms-key:{region}:{key_id}",
+                    f"Schedule deletion of {KEY_NAME} in {region}",
+                    command=[
+                        "--region",
+                        region,
+                        "kms",
+                        "management",
+                        "key",
+                        "schedule-deletion",
+                        "--endpoint",
+                        endpoint,
+                        "--key-id",
+                        key_id,
+                        "--time-of-deletion",
+                        kms_deletion_time,
+                    ],
+                    details={"deletion_time": kms_deletion_time},
+                )
+                self.kms_pending = True
+            self.action(
+                f"kms-vault:{region}:{vault_id}",
+                f"Schedule deletion of {VAULT_NAME} in {region}",
+                command=[
+                    "--region",
+                    region,
+                    "kms",
+                    "management",
+                    "vault",
+                    "schedule-deletion",
+                    "--endpoint",
+                    endpoint,
+                    "--vault-id",
+                    vault_id,
+                    "--time-of-deletion",
+                    kms_deletion_time,
+                ],
+                details={"deletion_time": kms_deletion_time},
+            )
+            self.kms_pending = True
+
+

--- a/oci-integration-cleanup/oci_cleanup/domains/kms.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/kms.py
@@ -3,8 +3,8 @@
 Safety boundary: enforces exact names, ownership, compartment, and OCI minimum delays.
 Cleanup sequence role: runs at the end of each regional cleanup sequence.
 
-``KmsMixin`` schedules secret, master-key, and vault deletion. Stable deletion timestamps 
-are stored in the manifest so retries reuse the original schedule and preserve the required 
+``KmsMixin`` schedules secret, master-key, and vault deletion. Stable deletion timestamps
+are stored in the manifest so retries reuse the original schedule and preserve the required
 child-before-parent order.
 """
 
@@ -182,5 +182,3 @@ class KmsMixin:
                 details={"deletion_time": kms_deletion_time},
             )
             self.kms_pending = True
-
-

--- a/oci-integration-cleanup/oci_cleanup/domains/kms.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/kms.py
@@ -3,9 +3,9 @@
 Safety boundary: enforces exact names, ownership, compartment, and OCI minimum delays.
 Cleanup sequence role: runs at the end of each regional cleanup sequence.
 
-``KmsMixin`` schedules secret, master-key, and vault deletion. Stable deletion timestamps
-are stored in the manifest so retries reuse the original schedule and preserve the required
-child-before-parent order.
+``KmsMixin`` schedules active secrets, master keys, and vaults with timestamps computed
+for the current run. Resources already pending deletion are left to OCI, while active
+children are always scheduled before their parent vault.
 """
 
 from __future__ import annotations
@@ -29,27 +29,21 @@ from ..resources import (
 
 
 class KmsMixin:
-    """Schedule deletion of Quickstart secrets, keys, and vaults."""
+    """Schedule active Quickstart secrets, keys, and vaults for deletion."""
 
-    def _deletion_time(self, manifest_key: str, delay: dt.timedelta) -> str:
-        with self.manifest.lock:
-            existing = self.manifest.data["context"].get(manifest_key)
-            if existing:
-                return str(existing)
-            value = (
-                dt.datetime.now(dt.timezone.utc)
-                + delay
-            ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-            self.manifest.data["context"][manifest_key] = value
-            return value
+    @staticmethod
+    def _deletion_time(delay: dt.timedelta) -> str:
+        """Return a fresh OCI deletion timestamp valid for this cleanup run."""
+
+        return (
+            dt.datetime.now(dt.timezone.utc) + delay
+        ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
     def cleanup_kms(self, context: CleanupContext, region: str) -> None:
-        secret_deletion_time = self._deletion_time(
-            "secret_deletion_time", SECRET_DELETION_DELAY
-        )
-        kms_deletion_time = self._deletion_time(
-            "kms_deletion_time", KMS_DELETION_DELAY
-        )
+        """Schedule active owned KMS resources using run-local timestamps."""
+
+        secret_deletion_time = self._deletion_time(SECRET_DELETION_DELAY)
+        kms_deletion_time = self._deletion_time(KMS_DELETION_DELAY)
         secrets = self._list_region(
             region,
             [
@@ -70,6 +64,8 @@ class KmsMixin:
             if lifecycle_state(secret) == "PENDING_DELETION":
                 self.kms_pending = True
                 continue
+            if lifecycle_state(secret) != "ACTIVE":
+                continue
             identifier = resource_id(secret)
             self.action(
                 f"secret:{region}:{identifier}",
@@ -85,7 +81,11 @@ class KmsMixin:
                     "--time-of-deletion",
                     secret_deletion_time,
                 ],
-                details={"deletion_time": secret_deletion_time},
+                details={
+                    "deletion_time": secret_deletion_time,
+                    "resource_id": identifier,
+                    "region": region,
+                },
             )
             self.kms_pending = True
 
@@ -110,11 +110,15 @@ class KmsMixin:
             if lifecycle_state(vault) == "PENDING_DELETION":
                 self.kms_pending = True
                 continue
+            if lifecycle_state(vault) != "ACTIVE":
+                continue
             vault_id = resource_id(vault)
             endpoint = resource_management_endpoint(vault)
             if not endpoint:
-                self.failures.append(
-                    f"Owned vault {vault_id} has no management endpoint"
+                self._record_failure(
+                    f"Owned vault {vault_id} in {region} has no management endpoint",
+                    resource_id=vault_id,
+                    region=region,
                 )
                 continue
             keys = self.oci.list(
@@ -141,6 +145,8 @@ class KmsMixin:
                 if lifecycle_state(key) == "PENDING_DELETION":
                     self.kms_pending = True
                     continue
+                if lifecycle_state(key) not in {"ACTIVE", "ENABLED"}:
+                    continue
                 key_id = resource_id(key)
                 self.action(
                     f"kms-key:{region}:{key_id}",
@@ -159,7 +165,11 @@ class KmsMixin:
                         "--time-of-deletion",
                         kms_deletion_time,
                     ],
-                    details={"deletion_time": kms_deletion_time},
+                    details={
+                        "deletion_time": kms_deletion_time,
+                        "resource_id": key_id,
+                        "region": region,
+                    },
                 )
                 self.kms_pending = True
             self.action(
@@ -179,6 +189,10 @@ class KmsMixin:
                     "--time-of-deletion",
                     kms_deletion_time,
                 ],
-                details={"deletion_time": kms_deletion_time},
+                details={
+                    "deletion_time": kms_deletion_time,
+                    "resource_id": vault_id,
+                    "region": region,
+                },
             )
             self.kms_pending = True

--- a/oci-integration-cleanup/oci_cleanup/region.py
+++ b/oci-integration-cleanup/oci_cleanup/region.py
@@ -18,6 +18,8 @@ class RegionMixin:
         self.cleanup_functions(context, region)
         LOGGER.info("[%s] Checking Quickstart networking", region)
         self.cleanup_network(context, region)
+        LOGGER.info("[%s] Checking KMS resources", region)
+        self.cleanup_kms(context, region)
 
 
     def _cleanup_region_safely(

--- a/oci-integration-cleanup/oci_cleanup/resources.py
+++ b/oci-integration-cleanup/oci_cleanup/resources.py
@@ -67,6 +67,14 @@ def resource_type(resource: dict[str, Any]) -> str:
     )
 
 
+def resource_management_endpoint(resource: dict[str, Any]) -> str:
+    return str(
+        resource.get("management-endpoint")
+        or resource.get("management_endpoint")
+        or ""
+    )
+
+
 def lifecycle_state(resource: dict[str, Any]) -> str:
     return str(
         resource.get("lifecycle-state")

--- a/oci-integration-cleanup/tests/test_integration_cleanup.py
+++ b/oci-integration-cleanup/tests/test_integration_cleanup.py
@@ -1,5 +1,6 @@
 import argparse
 import contextlib
+import datetime as dt
 import io
 import json
 import os
@@ -1385,6 +1386,7 @@ class CleanupTestCase(unittest.TestCase):
         self.assertEqual("DELETED", stream_delete[-1])
 
     def test_kms_actions_use_minimum_buffered_deletion_times(self):
+        before = dt.datetime.now(dt.timezone.utc)
         oci = FakeOci()
         oci.add_list(
             "vault secret list",
@@ -1395,6 +1397,7 @@ class CleanupTestCase(unittest.TestCase):
                         "secret-name": cleanup.SECRET_NAME,
                         "name": cleanup.SECRET_NAME,
                         "compartment-id": COMPARTMENT,
+                        "lifecycle-state": "ACTIVE",
                     }
                 )
             ],
@@ -1408,6 +1411,7 @@ class CleanupTestCase(unittest.TestCase):
                         "display-name": cleanup.VAULT_NAME,
                         "compartment-id": COMPARTMENT,
                         "management-endpoint": "https://kms.example",
+                        "lifecycle-state": "ACTIVE",
                     }
                 )
             ],
@@ -1420,6 +1424,7 @@ class CleanupTestCase(unittest.TestCase):
                         "id": "key",
                         "display-name": cleanup.KEY_NAME,
                         "compartment-id": COMPARTMENT,
+                        "lifecycle-state": "ENABLED",
                     }
                 )
             ],
@@ -1431,9 +1436,121 @@ class CleanupTestCase(unittest.TestCase):
             for action in cleaner.planned
             if action["id"].startswith(("secret:", "kms-key:", "kms-vault:"))
         }
+        secret_time = dt.datetime.fromisoformat(
+            times_by_kind["secret"].replace("Z", "+00:00")
+        )
+        kms_time = dt.datetime.fromisoformat(
+            times_by_kind["kms-key"].replace("Z", "+00:00")
+        )
+        self.assertGreaterEqual(
+            secret_time,
+            (before + cleanup.SECRET_DELETION_DELAY).replace(microsecond=0),
+        )
+        self.assertGreaterEqual(
+            kms_time,
+            (before + cleanup.KMS_DELETION_DELAY).replace(microsecond=0),
+        )
         self.assertNotEqual(times_by_kind["secret"], times_by_kind["kms-key"])
         self.assertEqual(times_by_kind["kms-key"], times_by_kind["kms-vault"])
+        action_ids = [action["id"] for action in cleaner.planned]
+        self.assertLess(
+            action_ids.index(f"kms-key:{HOME_REGION}:key"),
+            action_ids.index(f"kms-vault:{HOME_REGION}:vault"),
+        )
         self.assertTrue(cleaner.kms_pending)
+
+    def test_kms_pending_resources_are_skipped_on_stateless_rerun(self):
+        oci = FakeOci()
+        oci.add_list(
+            "vault secret list",
+            [
+                owned(
+                    {
+                        "id": "secret",
+                        "secret-name": cleanup.SECRET_NAME,
+                        "compartment-id": COMPARTMENT,
+                        "lifecycle-state": "PENDING_DELETION",
+                    }
+                )
+            ],
+        )
+        oci.add_list(
+            "kms management vault list",
+            [
+                owned(
+                    {
+                        "id": "vault",
+                        "display-name": cleanup.VAULT_NAME,
+                        "compartment-id": COMPARTMENT,
+                        "management-endpoint": "https://kms.example",
+                        "lifecycle-state": "ACTIVE",
+                    }
+                )
+            ],
+        )
+        oci.add_list(
+            "kms management key list",
+            [
+                owned(
+                    {
+                        "id": "key",
+                        "display-name": cleanup.KEY_NAME,
+                        "compartment-id": COMPARTMENT,
+                        "lifecycle-state": "PENDING_DELETION",
+                    }
+                )
+            ],
+        )
+        cleaner = self.make_cleaner(oci=oci)
+
+        with patch.object(
+            cleaner,
+            "_deletion_time",
+            side_effect=[
+                "2026-08-19T12:00:00Z",
+                "2026-08-25T12:00:00Z",
+                "2026-08-19T13:00:00Z",
+                "2026-08-25T13:00:00Z",
+            ],
+        ):
+            cleaner.cleanup_kms(context(), HOME_REGION)
+            cleaner.cleanup_kms(context(), HOME_REGION)
+
+        self.assertEqual(
+            [
+                f"kms-vault:{HOME_REGION}:vault",
+                f"kms-vault:{HOME_REGION}:vault",
+            ],
+            [action["id"] for action in cleaner.planned],
+        )
+        self.assertEqual(
+            ["2026-08-25T12:00:00Z", "2026-08-25T13:00:00Z"],
+            [action["deletion_time"] for action in cleaner.planned],
+        )
+        self.assertTrue(cleaner.kms_pending)
+
+    def test_kms_missing_vault_endpoint_records_structured_failure(self):
+        oci = FakeOci()
+        oci.add_list(
+            "kms management vault list",
+            [
+                owned(
+                    {
+                        "id": "vault",
+                        "display-name": cleanup.VAULT_NAME,
+                        "compartment-id": COMPARTMENT,
+                        "lifecycle-state": "ACTIVE",
+                    }
+                )
+            ],
+        )
+        cleaner = self.make_cleaner(oci=oci)
+
+        cleaner.cleanup_kms(context(), HOME_REGION)
+
+        self.assertEqual("vault", cleaner.failures[0]["resource_id"])
+        self.assertEqual(HOME_REGION, cleaner.failures[0]["region"])
+        self.assertIn("no management endpoint", cleaner.failures[0]["message"])
 
     def test_run_cleans_regions_concurrently(self):
         cleaner = self.make_cleaner(

--- a/oci-integration-cleanup/tests/test_integration_cleanup.py
+++ b/oci-integration-cleanup/tests/test_integration_cleanup.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 import integration_cleanup as cleanup
 import oci_cleanup
-from oci_cleanup.resources import resource_field
+from oci_cleanup.resources import resource_field, resource_management_endpoint
 
 
 TENANCY = "ocid1.tenancy.oc1..test"
@@ -129,6 +129,20 @@ def extra_candidate(
 
 
 class CleanupTestCase(unittest.TestCase):
+    def test_resource_management_endpoint_normalizes_oci_field_names(self):
+        self.assertEqual(
+            "https://hyphen.example",
+            resource_management_endpoint(
+                {"management-endpoint": "https://hyphen.example"}
+            ),
+        )
+        self.assertEqual(
+            "https://underscore.example",
+            resource_management_endpoint(
+                {"management_endpoint": "https://underscore.example"}
+            ),
+        )
+
     def test_facade_reexports_public_package_api(self):
         self.assertEqual(
             set(cleanup.__all__),

--- a/oci-integration-cleanup/tests/test_integration_cleanup.py
+++ b/oci-integration-cleanup/tests/test_integration_cleanup.py
@@ -1370,6 +1370,57 @@ class CleanupTestCase(unittest.TestCase):
         self.assertEqual("DELETED", event_delete[-1])
         self.assertEqual("DELETED", stream_delete[-1])
 
+    def test_kms_actions_use_minimum_buffered_deletion_times(self):
+        oci = FakeOci()
+        oci.add_list(
+            "vault secret list",
+            [
+                owned(
+                    {
+                        "id": "secret",
+                        "secret-name": cleanup.SECRET_NAME,
+                        "name": cleanup.SECRET_NAME,
+                        "compartment-id": COMPARTMENT,
+                    }
+                )
+            ],
+        )
+        oci.add_list(
+            "kms management vault list",
+            [
+                owned(
+                    {
+                        "id": "vault",
+                        "display-name": cleanup.VAULT_NAME,
+                        "compartment-id": COMPARTMENT,
+                        "management-endpoint": "https://kms.example",
+                    }
+                )
+            ],
+        )
+        oci.add_list(
+            "kms management key list",
+            [
+                owned(
+                    {
+                        "id": "key",
+                        "display-name": cleanup.KEY_NAME,
+                        "compartment-id": COMPARTMENT,
+                    }
+                )
+            ],
+        )
+        cleaner = self.make_cleaner(oci=oci)
+        cleaner.cleanup_kms(context(), HOME_REGION)
+        times_by_kind = {
+            action["id"].split(":", 1)[0]: action.get("deletion_time")
+            for action in cleaner.planned
+            if action["id"].startswith(("secret:", "kms-key:", "kms-vault:"))
+        }
+        self.assertNotEqual(times_by_kind["secret"], times_by_kind["kms-key"])
+        self.assertEqual(times_by_kind["kms-key"], times_by_kind["kms-vault"])
+        self.assertTrue(cleaner.kms_pending)
+
     def test_run_cleans_regions_concurrently(self):
         cleaner = self.make_cleaner(
             args=SimpleNamespace(region_workers=2)


### PR DESCRIPTION
## Summary
- schedule deletion of the Datadog API-key secret before its key and vault
- persist OCI-compliant deletion timestamps so retries remain stable
- report throttling and vault quota remediation clearly

## Stack
- Depends on https://github.com/DataDog/oracle-cloud-integration/pull/167
- For context on how this package works - [README](https://github.com/DataDog/oracle-cloud-integration/blob/3fa9a804a2526815d31fae7ac37db982132c75e0/oci-integration-cleanup/README.md)

## Test plan
- [x] `python3 -m unittest discover -s oci-integration-cleanup/tests -p 'test_*.py' -v` (32 tests)