### PR TITLE
Complete stack, identity, and compartment teardown

### DIFF
--- a/.claude/skills/datadog-onboarding-testing/reference.md
+++ b/.claude/skills/datadog-onboarding-testing/reference.md
@@ -127,34 +127,35 @@ Use `integration_cleanup.py` when the parent or child Terraform state is
 missing, corrupted, or no longer describes the resources that were created.
 The script discovers OCI resources by the `ownedby=datadog` tag and stronger
 checks for untaggable resources, and removes them in dependency order. Disable
-or remove the integration in Datadog separately before execute mode so the
-control plane cannot recreate managed resources.
+or remove the integration in Datadog separately before using
+`--dry-run false` so the control plane cannot recreate managed resources. The
+tenancy OCID is read from the selected OCI CLI profile.
 
 Always run a dry-run first:
 
 ```bash
 python3 oci-integration-cleanup/integration_cleanup.py \
-  --tenancy-id "$TENANCY_OCID"
+  --profile "$OCI_PROFILE" \
+  --dry-run true
 ```
 
 Execute only after reviewing the JSON inventory:
 
 ```bash
 python3 oci-integration-cleanup/integration_cleanup.py \
-  --tenancy-id "$TENANCY_OCID" \
+  --profile "$OCI_PROFILE" \
   --confirm-tenancy-id "$TENANCY_OCID" \
-  --state-file /tmp/datadog-cleanup-state.json \
-  --execute
+  --dry-run false
 ```
 
-Add `--compartment-id` if discovery is ambiguous. Add
+Add `--compartment-ocid` if discovery is ambiguous. Add
 `--delete-compartment` only when the auto-created compartment should also be
 removed; the script refuses if any child, unowned, unknown, or pending KMS
 resource remains.
 
-Use the same execute command and state file to resume. OCI KMS deletion has a
-minimum seven-day delay, so final compartment cleanup usually requires a later
-run.
+The cleanup is stateless. Rerun the same command to rediscover OCI state and
+retry resources that remain live. OCI KMS deletion has a minimum seven-day
+delay, so final compartment cleanup usually requires a later run.
 
 Use `delete_stack.sh` instead when the problem is limited to known regional
 stacks whose Resource Manager state is still intact.

--- a/.claude/skills/datadog-onboarding-testing/reference.md
+++ b/.claude/skills/datadog-onboarding-testing/reference.md
@@ -121,6 +121,46 @@ Digest matches `terraform_data.stack_digest.id` from parent apply (check RM job 
 
 ---
 
+## Destroy — full state-loss remediation
+
+Use `integration_cleanup.py` when the parent or child Terraform state is
+missing, corrupted, or no longer describes the resources that were created.
+The script discovers OCI resources by the `ownedby=datadog` tag and stronger
+checks for untaggable resources, and removes them in dependency order. Disable
+or remove the integration in Datadog separately before execute mode so the
+control plane cannot recreate managed resources.
+
+Always run a dry-run first:
+
+```bash
+python3 oci-integration-cleanup/integration_cleanup.py \
+  --tenancy-id "$TENANCY_OCID"
+```
+
+Execute only after reviewing the JSON inventory:
+
+```bash
+python3 oci-integration-cleanup/integration_cleanup.py \
+  --tenancy-id "$TENANCY_OCID" \
+  --confirm-tenancy-id "$TENANCY_OCID" \
+  --state-file /tmp/datadog-cleanup-state.json \
+  --execute
+```
+
+Add `--compartment-id` if discovery is ambiguous. Add
+`--delete-compartment` only when the auto-created compartment should also be
+removed; the script refuses if any child, unowned, unknown, or pending KMS
+resource remains.
+
+Use the same execute command and state file to resume. OCI KMS deletion has a
+minimum seven-day delay, so final compartment cleanup usually requires a later
+run.
+
+Use `delete_stack.sh` instead when the problem is limited to known regional
+stacks whose Resource Manager state is still intact.
+
+---
+
 ## Common failures
 
 | Symptom | Likely cause |

--- a/datadog-integration/regional_stack.tf
+++ b/datadog-integration/regional_stack.tf
@@ -59,6 +59,7 @@ resource "null_resource" "regional_stacks_create_apply" {
       echo "No stack found in the compartment by the name $STACK_NAME in region ${each.key}. Creating..."
       STACK_ID=$(oci resource-manager stack create --compartment-id ${module.compartment.id} --display-name $STACK_NAME \
       --config-source ${path.module}/modules/regional-stacks/dd_regional_stack.zip  --variables "$VARIABLES_JSON" \
+      --freeform-tags '${jsonencode(local.tags)}' \
       ${local.stack_create_defined_tags_flag} \
       --wait-for-state ACTIVE \
       --max-wait-seconds 120 \
@@ -71,6 +72,7 @@ resource "null_resource" "regional_stacks_create_apply" {
       echo "Refreshing config source and variables for existing stack $STACK_ID in region ${each.key}..."
       if ! UPDATE_OUTPUT=$(oci resource-manager stack update --stack-id "$STACK_ID" --force \
       --config-source ${path.module}/modules/regional-stacks/dd_regional_stack.zip --variables "$VARIABLES_JSON" \
+      --freeform-tags '${jsonencode(local.tags)}' \
       ${local.stack_create_defined_tags_flag} \
       --region ${each.key} 2>&1); then
         echo "ERROR: Failed to update stack $STACK_ID in region ${each.key}: $UPDATE_OUTPUT"

--- a/datadog-integration/regional_stack.tf
+++ b/datadog-integration/regional_stack.tf
@@ -59,7 +59,6 @@ resource "null_resource" "regional_stacks_create_apply" {
       echo "No stack found in the compartment by the name $STACK_NAME in region ${each.key}. Creating..."
       STACK_ID=$(oci resource-manager stack create --compartment-id ${module.compartment.id} --display-name $STACK_NAME \
       --config-source ${path.module}/modules/regional-stacks/dd_regional_stack.zip  --variables "$VARIABLES_JSON" \
-      --freeform-tags '${jsonencode(local.tags)}' \
       ${local.stack_create_defined_tags_flag} \
       --wait-for-state ACTIVE \
       --max-wait-seconds 120 \
@@ -72,7 +71,6 @@ resource "null_resource" "regional_stacks_create_apply" {
       echo "Refreshing config source and variables for existing stack $STACK_ID in region ${each.key}..."
       if ! UPDATE_OUTPUT=$(oci resource-manager stack update --stack-id "$STACK_ID" --force \
       --config-source ${path.module}/modules/regional-stacks/dd_regional_stack.zip --variables "$VARIABLES_JSON" \
-      --freeform-tags '${jsonencode(local.tags)}' \
       ${local.stack_create_defined_tags_flag} \
       --region ${each.key} 2>&1); then
         echo "ERROR: Failed to update stack $STACK_ID in region ${each.key}: $UPDATE_OUTPUT"

--- a/oci-integration-cleanup/README.md
+++ b/oci-integration-cleanup/README.md
@@ -27,8 +27,10 @@ python3 oci-integration-cleanup/integration_cleanup.py \
 
 `--compartment-ocid` is optional when discovery identifies exactly one target
 compartment. Add `--parent-stack-id` to destroy the parent Resource Manager
-stack. Add `--delete-compartment` only when the proven Quickstart-created
-compartment should also be removed. Use `--oci-bin` or `OCI_BIN` when the OCI
-CLI is not available as `oci` on `PATH`.
+stack. Stack deletion requires the freeform tag `ownedby=datadog`; add it
+manually to parent or legacy regional stacks that predate automatic tagging.
+Add `--delete-compartment` only when the proven Quickstart-created compartment
+should also be removed. Use `--oci-bin` or `OCI_BIN` when the OCI CLI is not
+available as `oci` on `PATH`.
 
 Rerun the same command to retry resources that remain live.

--- a/oci-integration-cleanup/integration_cleanup.py
+++ b/oci-integration-cleanup/integration_cleanup.py
@@ -25,10 +25,14 @@ from oci_cleanup import *  # noqa: F401,F403
 from oci_cleanup import __all__ as package_api
 from oci_cleanup.base import CleanupBase
 from oci_cleanup.discovery import DiscoveryMixin
+from oci_cleanup.domains.compartment import CompartmentMixin
 from oci_cleanup.domains.extras import ExtrasMixin
+from oci_cleanup.domains.identity import IdentityMixin
 from oci_cleanup.domains.kms import KmsMixin
 from oci_cleanup.domains.network import NetworkMixin
 from oci_cleanup.domains.services import ServicesMixin
+from oci_cleanup.domains.stacks import StacksMixin
+from oci_cleanup.domains.tags import TagsMixin
 from oci_cleanup.engine import EngineMixin
 from oci_cleanup.region import RegionMixin
 
@@ -40,12 +44,16 @@ class QuickstartCleanup(
     DiscoveryMixin,
     ExtrasMixin,
     RegionMixin,
+    StacksMixin,
     ServicesMixin,
     NetworkMixin,
     KmsMixin,
+    IdentityMixin,
+    TagsMixin,
+    CompartmentMixin,
     CleanupBase,
 ):
-    """Remove Quickstart resources and schedule KMS deletion."""
+    """Safely discover and remove one Datadog OCI Quickstart installation."""
 
 
 def _parse_bool(value: str) -> bool:

--- a/oci-integration-cleanup/oci_cleanup/base.py
+++ b/oci-integration-cleanup/oci_cleanup/base.py
@@ -96,6 +96,7 @@ class CleanupBase:
         resource_id: str = "",
         region: str = "",
         error: Optional[Exception] = None,
+        error_code: Optional[str] = None,
         deletion_message: str = "",
     ) -> dict[str, Any]:
         """Record a consistently shaped failure for summaries and callers."""
@@ -104,7 +105,9 @@ class CleanupBase:
             "message": message,
             "resource_id": resource_id,
             "region": region or str(getattr(error, "region", "") or ""),
-            "error_code": str(getattr(error, "code", "") or "") or None,
+            "error_code": (
+                str(error_code or getattr(error, "code", "") or "") or None
+            ),
             "deletion_message": (
                 deletion_message
                 or str(getattr(error, "service_message", "") or "")

--- a/oci-integration-cleanup/oci_cleanup/domains/compartment.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/compartment.py
@@ -40,15 +40,36 @@ class CompartmentMixin:
         children = [
             child
             for child in children
-            if str(
-                child.get("lifecycle-state")
-                or child.get("lifecycle_state")
-                or "ACTIVE"
-            ).upper()
-            not in {"DELETED", "DELETING"}
+            if lifecycle_state(child) not in {"DELETED", "DELETING"}
         ]
 
         residuals: list[dict[str, Any]] = []
+        namespace = ""
+        try:
+            namespace_payload = self.oci.run(
+                [
+                    "--region",
+                    context.home_region,
+                    "os",
+                    "ns",
+                    "get",
+                ],
+                attempts=2,
+            )
+            namespace = str(namespace_payload.get("data", ""))
+            if not namespace:
+                raise CleanupError("Object Storage namespace was empty")
+        except Exception as error:
+            residuals.append(
+                {
+                    "id": "inventory-error:object-storage-namespace",
+                    "display-name": f"Object Storage namespace lookup failed: {error}",
+                    "resource-type": "InventoryError",
+                    "compartment-id": context.compartment_id,
+                    "_region": context.home_region,
+                }
+            )
+
         for region in context.regions:
             payload = self.oci.run(
                 [
@@ -176,12 +197,8 @@ class CompartmentMixin:
                     )
 
             try:
-                namespace_payload = self.oci.run(
-                    ["--region", region, "os", "ns", "get"], attempts=2
-                )
-                namespace = str(namespace_payload.get("data", ""))
                 if not namespace:
-                    raise CleanupError("Object Storage namespace was empty")
+                    continue
                 for bucket in self._list_region(
                     region,
                     [

--- a/oci-integration-cleanup/oci_cleanup/domains/compartment.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/compartment.py
@@ -243,9 +243,11 @@ class CompartmentMixin:
             return
         LOGGER.info("Stage 5/5: validating optional compartment deletion")
         if not context.compartment:
-            self.failures.append(
+            self._record_failure(
                 "Compartment deletion requested, but the target compartment was "
-                "not proven to be Quickstart-created and tagged"
+                "not proven to be Quickstart-created and tagged",
+                resource_id=context.compartment_id,
+                region=context.home_region,
             )
             return
         if (
@@ -254,9 +256,11 @@ class CompartmentMixin:
             not in {"", AUTO_COMPARTMENT_DESCRIPTION}
             or not is_owned(context.compartment)
         ):
-            self.failures.append(
+            self._record_failure(
                 "Compartment deletion requested, but ownership/name/description "
-                "validation failed"
+                "validation failed",
+                resource_id=context.compartment_id,
+                region=context.home_region,
             )
             return
         if not self.execute:
@@ -286,34 +290,13 @@ class CompartmentMixin:
             return
         residuals, children = self.compartment_residuals(context)
         if residuals or children or self.kms_pending:
-            self.failures.append(
+            self._record_failure(
                 "Compartment preserved: "
                 f"{len(residuals)} residual resources, {len(children)} child "
-                f"compartments, kms_pending={self.kms_pending}"
+                f"compartments, kms_pending={self.kms_pending}",
+                resource_id=context.compartment_id,
+                region=context.home_region,
             )
-            self.manifest.data["compartment_blockers"] = {
-                "resources": [
-                    {
-                        "id": resource_id(resource),
-                        "name": resource_name(resource),
-                        "type": resource.get("resource-type")
-                        or resource.get("resource_type"),
-                        "region": resource.get("_region"),
-                        "owned": is_owned(resource),
-                    }
-                    for resource in residuals
-                ],
-                "child_compartments": [
-                    {
-                        "id": resource_id(child),
-                        "name": resource_name(child),
-                    }
-                    for child in children
-                ],
-                "kms_pending": self.kms_pending,
-            }
-            if self.execute:
-                self.manifest.save()
             return
         self.action(
             f"compartment:{context.compartment_id}",

--- a/oci-integration-cleanup/oci_cleanup/domains/compartment.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/compartment.py
@@ -1,0 +1,314 @@
+"""Responsibility: inspect residual resources and optionally delete the Datadog compartment.
+
+Safety boundary: requires proven auto-creation, explicit opt-in, and an empty safe residual scan.
+Cleanup sequence role: performs the final resource-container cleanup.
+
+``CompartmentMixin`` inventories supported OCI resource families across the target
+and nested compartments, distinguishing ignorable terminal objects from blockers.
+It deletes the compartment only when discovery evidence and the residual scan agree.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..constants import AUTO_COMPARTMENT_DESCRIPTION, AUTO_COMPARTMENT_NAME, LOGGER
+from ..errors import CleanupError
+from ..models import CleanupContext
+from ..resources import data_items, is_owned, lifecycle_state, resource_id, resource_name
+
+
+class CompartmentMixin:
+    """Inspect residuals and safely delete the target compartment."""
+
+    def compartment_residuals(
+        self, context: CleanupContext
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        children = self.oci.list(
+            [
+                "--region",
+                context.home_region,
+                "iam",
+                "compartment",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+                "--compartment-id-in-subtree",
+                "false",
+            ]
+        )
+        children = [
+            child
+            for child in children
+            if str(
+                child.get("lifecycle-state")
+                or child.get("lifecycle_state")
+                or "ACTIVE"
+            ).upper()
+            not in {"DELETED", "DELETING"}
+        ]
+
+        residuals: list[dict[str, Any]] = []
+        for region in context.regions:
+            payload = self.oci.run(
+                [
+                    "--region",
+                    region,
+                    "search",
+                    "resource",
+                    "structured-search",
+                    "--query-text",
+                    f"query all resources where compartmentId = "
+                    f"'{context.compartment_id}'",
+                ],
+                attempts=2,
+            )
+            for resource in data_items(payload):
+                copy = dict(resource)
+                copy["_region"] = region
+                residuals.append(copy)
+
+            # Resource Search is eventually consistent and does not cover every
+            # service equally. Re-list the services touched by cleanup so a
+            # missed or untagged resource blocks compartment deletion.
+            service_lists = [
+                [
+                    "resource-manager",
+                    "stack",
+                    "list",
+                    "--compartment-id",
+                    context.compartment_id,
+                ],
+                [
+                    "sch",
+                    "service-connector",
+                    "list",
+                    "--compartment-id",
+                    context.compartment_id,
+                ],
+                [
+                    "events",
+                    "rule",
+                    "list",
+                    "--compartment-id",
+                    context.compartment_id,
+                ],
+                [
+                    "streaming",
+                    "admin",
+                    "stream",
+                    "list",
+                    "--compartment-id",
+                    context.compartment_id,
+                ],
+                [
+                    "fn",
+                    "application",
+                    "list",
+                    "--compartment-id",
+                    context.compartment_id,
+                ],
+                [
+                    "network",
+                    "subnet",
+                    "list",
+                    "--compartment-id",
+                    context.compartment_id,
+                ],
+                [
+                    "network",
+                    "vcn",
+                    "list",
+                    "--compartment-id",
+                    context.compartment_id,
+                ],
+                [
+                    "network",
+                    "nat-gateway",
+                    "list",
+                    "--compartment-id",
+                    context.compartment_id,
+                ],
+                [
+                    "network",
+                    "service-gateway",
+                    "list",
+                    "--compartment-id",
+                    context.compartment_id,
+                ],
+                [
+                    "vault",
+                    "secret",
+                    "list",
+                    "--compartment-id",
+                    context.compartment_id,
+                ],
+                [
+                    "kms",
+                    "management",
+                    "vault",
+                    "list",
+                    "--compartment-id",
+                    context.compartment_id,
+                ],
+            ]
+            for service_args in service_lists:
+                try:
+                    for resource in self._list_region(region, service_args):
+                        if lifecycle_state(resource) not in {
+                            "DELETED",
+                            "DELETING",
+                            "TERMINATED",
+                            "TERMINATING",
+                        }:
+                            copy = dict(resource)
+                            copy["_region"] = region
+                            residuals.append(copy)
+                except Exception as error:
+                    residuals.append(
+                        {
+                            "id": f"inventory-error:{region}:{'-'.join(service_args[:3])}",
+                            "display-name": f"Inventory failed: {error}",
+                            "resource-type": "InventoryError",
+                            "compartment-id": context.compartment_id,
+                            "_region": region,
+                        }
+                    )
+
+            try:
+                namespace_payload = self.oci.run(
+                    ["--region", region, "os", "ns", "get"], attempts=2
+                )
+                namespace = str(namespace_payload.get("data", ""))
+                if not namespace:
+                    raise CleanupError("Object Storage namespace was empty")
+                for bucket in self._list_region(
+                    region,
+                    [
+                        "os",
+                        "bucket",
+                        "list",
+                        "--compartment-id",
+                        context.compartment_id,
+                        "--namespace-name",
+                        namespace,
+                    ],
+                ):
+                    copy = dict(bucket)
+                    copy["_region"] = region
+                    residuals.append(copy)
+            except Exception as error:
+                residuals.append(
+                    {
+                        "id": f"inventory-error:{region}:object-storage",
+                        "display-name": f"Object Storage inventory failed: {error}",
+                        "resource-type": "InventoryError",
+                        "compartment-id": context.compartment_id,
+                        "_region": region,
+                    }
+                )
+        unique: dict[str, dict[str, Any]] = {}
+        for resource in residuals:
+            identifier = resource_id(resource)
+            if identifier and identifier != context.compartment_id:
+                unique[identifier] = resource
+        return list(unique.values()), children
+
+    def delete_compartment(self, context: CleanupContext) -> None:
+        if not self.args.delete_compartment:
+            LOGGER.info("Compartment deletion was not requested")
+            return
+        LOGGER.info("Stage 5/5: validating optional compartment deletion")
+        if not context.compartment:
+            self.failures.append(
+                "Compartment deletion requested, but the target compartment was "
+                "not proven to be Quickstart-created and tagged"
+            )
+            return
+        if (
+            resource_name(context.compartment) != AUTO_COMPARTMENT_NAME
+            or str(context.compartment.get("description", ""))
+            not in {"", AUTO_COMPARTMENT_DESCRIPTION}
+            or not is_owned(context.compartment)
+        ):
+            self.failures.append(
+                "Compartment deletion requested, but ownership/name/description "
+                "validation failed"
+            )
+            return
+        if not self.execute:
+            self.action(
+                f"compartment:{context.compartment_id}",
+                (
+                    "Conditionally delete the Quickstart-created compartment "
+                    "after post-cleanup service inventories prove it is empty"
+                ),
+                command=[
+                    "--region",
+                    context.home_region,
+                    "iam",
+                    "compartment",
+                    "delete",
+                    "--compartment-id",
+                    context.compartment_id,
+                    "--force",
+                ],
+                details={
+                    "conditional": True,
+                    "requires_no_children": True,
+                    "requires_no_residual_resources": True,
+                    "requires_no_pending_kms": True,
+                },
+            )
+            return
+        residuals, children = self.compartment_residuals(context)
+        if residuals or children or self.kms_pending:
+            self.failures.append(
+                "Compartment preserved: "
+                f"{len(residuals)} residual resources, {len(children)} child "
+                f"compartments, kms_pending={self.kms_pending}"
+            )
+            self.manifest.data["compartment_blockers"] = {
+                "resources": [
+                    {
+                        "id": resource_id(resource),
+                        "name": resource_name(resource),
+                        "type": resource.get("resource-type")
+                        or resource.get("resource_type"),
+                        "region": resource.get("_region"),
+                        "owned": is_owned(resource),
+                    }
+                    for resource in residuals
+                ],
+                "child_compartments": [
+                    {
+                        "id": resource_id(child),
+                        "name": resource_name(child),
+                    }
+                    for child in children
+                ],
+                "kms_pending": self.kms_pending,
+            }
+            if self.execute:
+                self.manifest.save()
+            return
+        self.action(
+            f"compartment:{context.compartment_id}",
+            f"Delete empty Quickstart-created compartment {context.compartment_id}",
+            command=[
+                "--region",
+                context.home_region,
+                "iam",
+                "compartment",
+                "delete",
+                "--compartment-id",
+                context.compartment_id,
+                "--force",
+                "--wait-for-state",
+                "SUCCEEDED",
+                "--wait-for-state",
+                "FAILED",
+            ],
+        )
+
+

--- a/oci-integration-cleanup/oci_cleanup/domains/compartment.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/compartment.py
@@ -21,6 +21,28 @@ from ..resources import data_items, is_owned, lifecycle_state, resource_id, reso
 class CompartmentMixin:
     """Inspect residuals and safely delete the target compartment."""
 
+    def _safe_list(
+        self,
+        context: CleanupContext,
+        region: str,
+        service_args: list[str],
+        error_key: str,
+        error_prefix: str = "Inventory failed",
+    ) -> list[dict[str, Any]]:
+        try:
+            resources = self._list_region(region, service_args)
+            return [dict(resource, _region=region) for resource in resources]
+        except Exception as error:
+            return [
+                {
+                    "id": f"inventory-error:{region}:{error_key}",
+                    "display-name": f"{error_prefix}: {error}",
+                    "resource-type": "InventoryError",
+                    "compartment-id": context.compartment_id,
+                    "_region": region,
+                }
+            ]
+
     def compartment_residuals(
         self, context: CleanupContext
     ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
@@ -174,56 +196,40 @@ class CompartmentMixin:
                 ],
             ]
             for service_args in service_lists:
-                try:
-                    for resource in self._list_region(region, service_args):
-                        if lifecycle_state(resource) not in {
-                            "DELETED",
-                            "DELETING",
-                            "TERMINATED",
-                            "TERMINATING",
-                        }:
-                            copy = dict(resource)
-                            copy["_region"] = region
-                            residuals.append(copy)
-                except Exception as error:
-                    residuals.append(
-                        {
-                            "id": f"inventory-error:{region}:{'-'.join(service_args[:3])}",
-                            "display-name": f"Inventory failed: {error}",
-                            "resource-type": "InventoryError",
-                            "compartment-id": context.compartment_id,
-                            "_region": region,
-                        }
-                    )
-
-            try:
-                if not namespace:
-                    continue
-                for bucket in self._list_region(
+                for resource in self._safe_list(
+                    context,
                     region,
-                    [
-                        "os",
-                        "bucket",
-                        "list",
-                        "--compartment-id",
-                        context.compartment_id,
-                        "--namespace-name",
-                        namespace,
-                    ],
+                    service_args,
+                    "-".join(service_args[:3]),
                 ):
-                    copy = dict(bucket)
-                    copy["_region"] = region
-                    residuals.append(copy)
-            except Exception as error:
-                residuals.append(
-                    {
-                        "id": f"inventory-error:{region}:object-storage",
-                        "display-name": f"Object Storage inventory failed: {error}",
-                        "resource-type": "InventoryError",
-                        "compartment-id": context.compartment_id,
-                        "_region": region,
-                    }
+                    if lifecycle_state(resource) not in {
+                        "DELETED",
+                        "DELETING",
+                        "TERMINATED",
+                        "TERMINATING",
+                    }:
+                        residuals.append(resource)
+
+            if not namespace:
+                continue
+            bucket_args = [
+                "os",
+                "bucket",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+                "--namespace-name",
+                namespace,
+            ]
+            residuals.extend(
+                self._safe_list(
+                    context,
+                    region,
+                    bucket_args,
+                    "object-storage",
+                    "Object Storage inventory failed",
                 )
+            )
         unique: dict[str, dict[str, Any]] = {}
         for resource in residuals:
             identifier = resource_id(resource)

--- a/oci-integration-cleanup/oci_cleanup/domains/compartment.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/compartment.py
@@ -333,5 +333,3 @@ class CompartmentMixin:
                 "FAILED",
             ],
         )
-
-

--- a/oci-integration-cleanup/oci_cleanup/domains/identity.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/identity.py
@@ -1,0 +1,257 @@
+"""Responsibility: validate and remove Quickstart IAM domain and tenancy resources.
+
+Safety boundary: requires exact names, tags, descriptions, matching rules, and policy references.
+Cleanup sequence role: runs only after all regional cleanup succeeds.
+
+``IdentityMixin`` resolves domain-scoped users and groups alongside tenancy-scoped
+dynamic groups and policies, validates their cross-references, then removes them in
+dependency order. Domain endpoints are passed explicitly to OCI identity commands.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..constants import (
+    CONNECTOR_GROUP_DESCRIPTION,
+    CONNECTOR_GROUP_NAME,
+    DYNAMIC_POLICY_NAME,
+    FUNCTION_GROUP_DESCRIPTION,
+    FUNCTION_GROUP_NAME,
+    GROUP_NAME,
+    LOGGER,
+    USER_NAME,
+    USER_POLICY_NAME,
+)
+from ..models import CleanupContext
+from ..resources import exact_owned, is_owned, resource_id, resource_name
+
+
+class IdentityMixin:
+    """Validate and remove Quickstart IAM resources."""
+
+    def _domain_endpoint(self, domain: dict[str, Any]) -> str:
+        return str(domain.get("url") or domain.get("endpoint") or "")
+
+    def _identity_resources(
+        self, context: CleanupContext, kind: str
+    ) -> list[tuple[str, dict[str, Any]]]:
+        found: list[tuple[str, dict[str, Any]]] = []
+        for domain in context.domains:
+            endpoint = self._domain_endpoint(domain)
+            if not endpoint:
+                continue
+            resources = self.oci.list(
+                [
+                    "identity-domains",
+                    kind,
+                    "list",
+                    "--endpoint",
+                    endpoint,
+                ]
+            )
+            found.extend((endpoint, resource) for resource in resources)
+        return found
+
+    def _validated_dynamic_groups(
+        self,
+        context: CleanupContext,
+        policies: list[dict[str, Any]],
+    ) -> list[tuple[str, dict[str, Any]]]:
+        policy = next(
+            (
+                candidate
+                for candidate in policies
+                if exact_owned(
+                    candidate,
+                    expected_names={DYNAMIC_POLICY_NAME},
+                    compartment_id=context.tenancy_id,
+                )
+            ),
+            None,
+        )
+        if not policy:
+            return []
+        statements = "\n".join(str(value) for value in policy.get("statements", []))
+        expected = {
+            CONNECTOR_GROUP_NAME: (
+                CONNECTOR_GROUP_DESCRIPTION,
+                "serviceconnector",
+            ),
+            FUNCTION_GROUP_NAME: (FUNCTION_GROUP_DESCRIPTION, "fnfunc"),
+        }
+        validated: list[tuple[str, dict[str, Any]]] = []
+        for endpoint, group in self._identity_resources(
+            context, "dynamic-resource-groups"
+        ):
+            name = resource_name(group)
+            if name not in expected:
+                continue
+            description, resource_type = expected[name]
+            matching_rule = str(
+                group.get("matching-rule") or group.get("matching_rule") or ""
+            )
+            identifier = str(group.get("ocid") or resource_id(group))
+            expected_rule = (
+                f"All {{resource.type = '{resource_type}', "
+                f"resource.compartment.id = '{context.compartment_id}'}}"
+            )
+            correct_rule = " ".join(matching_rule.split()) == " ".join(
+                expected_rule.split()
+            )
+            if (
+                str(group.get("description", "")) == description
+                and correct_rule
+                and identifier
+                and identifier in statements
+            ):
+                validated.append((endpoint, group))
+            else:
+                self.failures.append(
+                    f"Dynamic group {name} failed ownership-chain validation; "
+                    "manual review required"
+                )
+        return validated
+
+    def cleanup_home_identity(self, context: CleanupContext) -> None:
+        LOGGER.info("Stage 3/5: cleaning home-region IAM and Identity Domains")
+        policies = self.oci.list(
+            [
+                "--region",
+                context.home_region,
+                "iam",
+                "policy",
+                "list",
+                "--compartment-id",
+                context.tenancy_id,
+            ]
+        )
+        validated_dynamic_groups = self._validated_dynamic_groups(context, policies)
+
+        for policy in policies:
+            if not exact_owned(
+                policy,
+                expected_names={USER_POLICY_NAME, DYNAMIC_POLICY_NAME},
+                compartment_id=context.tenancy_id,
+            ):
+                continue
+            identifier = resource_id(policy)
+            self.action(
+                f"policy:{identifier}",
+                f"Delete Datadog IAM policy {resource_name(policy)}",
+                command=[
+                    "--region",
+                    context.home_region,
+                    "iam",
+                    "policy",
+                    "delete",
+                    "--policy-id",
+                    identifier,
+                    "--force",
+                ],
+            )
+
+        for endpoint, group in validated_dynamic_groups:
+            identifier = resource_id(group)
+            self.action(
+                f"dynamic-group:{identifier}",
+                f"Delete validated dynamic resource group {resource_name(group)}",
+                command=[
+                    "identity-domains",
+                    "dynamic-resource-group",
+                    "delete",
+                    "--endpoint",
+                    endpoint,
+                    "--dynamic-resource-group-id",
+                    identifier,
+                    "--force-delete",
+                    "true",
+                ],
+            )
+
+        users = [
+            (endpoint, user)
+            for endpoint, user in self._identity_resources(context, "users")
+            if resource_name(user) == USER_NAME and is_owned(user)
+        ]
+        groups = [
+            (endpoint, group)
+            for endpoint, group in self._identity_resources(context, "groups")
+            if resource_name(group) == GROUP_NAME and is_owned(group)
+        ]
+        if len(users) > 1 or len(groups) > 1:
+            self.failures.append(
+                "Multiple tagged dd-svc users or dd-svc-admin groups found; "
+                "identity deletion requires manual review"
+            )
+            return
+
+        if users:
+            endpoint, user = users[0]
+            scim_user_id = resource_id(user)
+            api_keys = self.oci.list(
+                [
+                    "identity-domains",
+                    "api-keys",
+                    "list",
+                    "--endpoint",
+                    endpoint,
+                    "--filter",
+                    f'user.value eq "{scim_user_id}"',
+                ]
+            )
+            for api_key in api_keys:
+                identifier = resource_id(api_key)
+                self.action(
+                    f"api-key:{identifier}",
+                    f"Delete API key {identifier} belonging to tagged {USER_NAME}",
+                    command=[
+                        "identity-domains",
+                        "api-key",
+                        "delete",
+                        "--endpoint",
+                        endpoint,
+                        "--api-key-id",
+                        identifier,
+                        "--force",
+                    ],
+                )
+
+        if groups:
+            endpoint, group = groups[0]
+            identifier = resource_id(group)
+            self.action(
+                f"identity-group:{identifier}",
+                f"Delete tagged Identity Domain group {GROUP_NAME}",
+                command=[
+                    "identity-domains",
+                    "group",
+                    "delete",
+                    "--endpoint",
+                    endpoint,
+                    "--group-id",
+                    identifier,
+                    "--force-delete",
+                    "true",
+                ],
+            )
+        if users:
+            endpoint, user = users[0]
+            identifier = resource_id(user)
+            self.action(
+                f"identity-user:{identifier}",
+                f"Delete tagged Identity Domain user {USER_NAME}",
+                command=[
+                    "identity-domains",
+                    "user",
+                    "delete",
+                    "--endpoint",
+                    endpoint,
+                    "--user-id",
+                    identifier,
+                    "--force-delete",
+                    "true",
+                ],
+            )
+
+

--- a/oci-integration-cleanup/oci_cleanup/domains/identity.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/identity.py
@@ -107,9 +107,11 @@ class IdentityMixin:
             ):
                 validated.append((endpoint, group))
             else:
-                self.failures.append(
+                self._record_failure(
                     f"Dynamic group {name} failed ownership-chain validation; "
-                    "manual review required"
+                    "manual review required",
+                    resource_id=identifier,
+                    region=context.home_region,
                 )
         return validated
 
@@ -180,9 +182,16 @@ class IdentityMixin:
             if exact_owned(group, expected_names={GROUP_NAME})
         ]
         if len(users) > 1 or len(groups) > 1:
-            self.failures.append(
+            ambiguous_ids = [
+                resource_id(resource)
+                for _, resource in [*users, *groups]
+                if resource_id(resource)
+            ]
+            self._record_failure(
                 "Multiple tagged dd-svc users or dd-svc-admin groups found; "
-                "identity deletion requires manual review"
+                "identity deletion requires manual review",
+                resource_id=",".join(ambiguous_ids),
+                region=context.home_region,
             )
             return
 

--- a/oci-integration-cleanup/oci_cleanup/domains/identity.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/identity.py
@@ -253,5 +253,3 @@ class IdentityMixin:
                     "true",
                 ],
             )
-
-

--- a/oci-integration-cleanup/oci_cleanup/domains/identity.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/identity.py
@@ -24,7 +24,7 @@ from ..constants import (
     USER_POLICY_NAME,
 )
 from ..models import CleanupContext
-from ..resources import exact_owned, is_owned, resource_id, resource_name
+from ..resources import exact_owned, resource_id, resource_name
 
 
 class IdentityMixin:
@@ -172,12 +172,12 @@ class IdentityMixin:
         users = [
             (endpoint, user)
             for endpoint, user in self._identity_resources(context, "users")
-            if resource_name(user) == USER_NAME and is_owned(user)
+            if exact_owned(user, expected_names={USER_NAME})
         ]
         groups = [
             (endpoint, group)
             for endpoint, group in self._identity_resources(context, "groups")
-            if resource_name(group) == GROUP_NAME and is_owned(group)
+            if exact_owned(group, expected_names={GROUP_NAME})
         ]
         if len(users) > 1 or len(groups) > 1:
             self.failures.append(

--- a/oci-integration-cleanup/oci_cleanup/domains/stacks.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/stacks.py
@@ -4,21 +4,23 @@ Safety boundary: preserves failed stacks for retry and only accepts constrained 
 Cleanup sequence role: handles regional stacks before orphan services and the parent near the end.
 
 ``StacksMixin`` validates region-prefixed child stacks and the selected parent stack,
-starts Resource Manager destroy jobs, and checks terminal job status. A stack is
-recorded complete only after a successful destroy, leaving failures resumable.
+reconciles Resource Manager destroy jobs, and deletes a stack record only after
+OCI reports a successful destroy.
 """
 
 from __future__ import annotations
 
+import datetime as dt
 from typing import Any
 
 from ..constants import LOGGER, REGIONAL_STACK_PREFIX
-from ..errors import CleanupError, raw_error_message
+from ..errors import CleanupError
 from ..models import CleanupContext
 from ..resources import (
     exact_owned,
     is_owned,
     lifecycle_state,
+    resource_field,
     resource_id,
     resource_name,
 )
@@ -26,6 +28,86 @@ from ..resources import (
 
 class StacksMixin:
     """Destroy validated regional and parent Resource Manager stacks."""
+
+    @staticmethod
+    def _job_time(job: dict[str, Any]) -> tuple[int, Any]:
+        value = str(resource_field(job, "time-created", "") or "")
+        if not value:
+            return (0, "")
+        try:
+            parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=dt.timezone.utc)
+            return (2, parsed.timestamp())
+        except ValueError:
+            return (1, value)
+
+    @staticmethod
+    def _job_failure(job: dict[str, Any]) -> tuple[str | None, str]:
+        details = resource_field(job, "failure-details", {})
+        if not isinstance(details, dict):
+            return None, str(details or "")
+        code = str(
+            resource_field(job, "error-code", "")
+            or resource_field(details, "code", "")
+            or ""
+        )
+        message = str(
+            resource_field(details, "message", "")
+            or resource_field(job, "failure-message", "")
+            or ""
+        )
+        return code or None, message
+
+    def _wait_for_destroy_job(
+        self,
+        region: str,
+        job_id: str,
+    ) -> dict[str, Any]:
+        result = self.oci.run(
+            [
+                "--region",
+                region,
+                "resource-manager",
+                "job",
+                "get",
+                "--job-id",
+                job_id,
+                "--wait-for-state",
+                "SUCCEEDED",
+                "--wait-for-state",
+                "FAILED",
+                "--wait-for-state",
+                "CANCELED",
+            ],
+            attempts=2,
+        )
+        return result.get("data", result)
+
+    def _create_destroy_job(
+        self,
+        region: str,
+        stack_id: str,
+    ) -> dict[str, Any]:
+        result = self.oci.run(
+            [
+                "--region",
+                region,
+                "resource-manager",
+                "job",
+                "create-destroy-job",
+                "--stack-id",
+                stack_id,
+                "--execution-plan-strategy",
+                "AUTO_APPROVED",
+                "--wait-for-state",
+                "SUCCEEDED",
+                "--wait-for-state",
+                "FAILED",
+            ],
+            attempts=2,
+        )
+        return result.get("data", result)
 
     def _destroy_stack(
         self,
@@ -39,47 +121,69 @@ class StacksMixin:
         name = resource_name(stack)
         action_id = f"{action_prefix}:{region}:{stack_id}"
         description = f"Destroy and delete {stack_kind} stack {name} ({stack_id})"
-        if self.manifest.completed(action_id):
-            return True
-        self.planned.append(
-            {
-                "id": action_id,
-                "description": description,
-                "status": "planned" if not self.execute else "running",
-            }
-        )
+        action = {
+            "id": action_id,
+            "description": description,
+            "status": "planned" if not self.execute else "running",
+            "resource_id": stack_id,
+            "region": region,
+            "error_code": None,
+            "deletion_message": description,
+        }
+        self.planned.append(action)
         if not self.execute:
-            self.manifest.record_action(action_id, description, "planned")
             return True
 
-        self.manifest.record_action(action_id, description, "running")
-        self.manifest.save()
         try:
-            result = self.oci.run(
-                [
-                    "--region",
+            destroy_jobs = [
+                job
+                for job in self._list_region(
                     region,
-                    "resource-manager",
-                    "job",
-                    "create-destroy-job",
-                    "--stack-id",
-                    stack_id,
-                    "--execution-plan-strategy",
-                    "AUTO_APPROVED",
-                    "--wait-for-state",
-                    "SUCCEEDED",
-                    "--wait-for-state",
-                    "FAILED",
-                ],
-                attempts=2,
-            )
-            job = result.get("data", result)
-            state = lifecycle_state(job)
-            if state != "SUCCEEDED":
-                raise CleanupError(
-                    f"{stack_kind.capitalize()} destroy job for {stack_id} "
-                    f"ended in {state or 'UNKNOWN'}"
+                    [
+                        "resource-manager",
+                        "job",
+                        "list",
+                        "--stack-id",
+                        stack_id,
+                    ],
                 )
+                if str(resource_field(job, "operation", "")).upper() == "DESTROY"
+            ]
+            newest = max(destroy_jobs, key=self._job_time) if destroy_jobs else None
+            state = lifecycle_state(newest or {})
+            if newest and state in {"ACCEPTED", "IN_PROGRESS"}:
+                job_id = resource_id(newest)
+                if not job_id:
+                    raise CleanupError(
+                        f"Newest {stack_kind} destroy job for {stack_id} has no OCID"
+                    )
+                job = self._wait_for_destroy_job(region, job_id)
+                if lifecycle_state(job) in {"FAILED", "CANCELED", "CANCELLED"}:
+                    job = self._create_destroy_job(region, stack_id)
+            elif newest and state == "SUCCEEDED":
+                job = newest
+            elif newest is None or state in {"FAILED", "CANCELED", "CANCELLED"}:
+                job = self._create_destroy_job(region, stack_id)
+            else:
+                job = newest
+
+            final_state = lifecycle_state(job)
+            if final_state != "SUCCEEDED":
+                error_code, deletion_message = self._job_failure(job)
+                failure = self._record_failure(
+                    f"{stack_kind.capitalize()} destroy job for {stack_id} "
+                    f"ended in {final_state or 'UNKNOWN'}",
+                    resource_id=stack_id,
+                    region=region,
+                    error_code=error_code,
+                    deletion_message=deletion_message,
+                )
+                action["status"] = "failed"
+                action["error"] = failure["message"]
+                action["error_code"] = failure["error_code"]
+                action["deletion_message"] = failure["deletion_message"]
+                return False
+
             self.oci.run(
                 [
                     "--region",
@@ -96,33 +200,22 @@ class StacksMixin:
                 attempts=2,
                 allow_not_found=True,
             )
-            self.manifest.record_action(
-                action_id,
-                description,
-                "completed",
-                destroy_job_id=resource_id(job),
-            )
-            self.manifest.save()
+            action["status"] = "completed"
+            action["destroy_job_id"] = resource_id(job)
             return True
         except Exception as error:
             # Preserve the stack and its state. Direct orphan cleanup can still
             # proceed, but the failure remains visible and prevents IAM teardown.
-            message = f"{description}: {error}"
-            raw_error = raw_error_message(error)
-            self.failures.append(message)
-            self.manifest.record_action(
-                action_id,
-                description,
-                "failed",
-                error=str(error),
-                raw_error=raw_error,
+            failure = self._record_failure(
+                f"{description}: {error}",
+                resource_id=stack_id,
+                region=region,
+                error=error,
             )
-            self.manifest.record_error(
-                message,
-                action_id,
-                raw_error=raw_error,
-            )
-            self.manifest.save()
+            action["status"] = "failed"
+            action["error"] = str(error)
+            action["error_code"] = failure["error_code"]
+            action["deletion_message"] = failure["deletion_message"]
             return False
 
     def destroy_regional_stack(
@@ -173,8 +266,15 @@ class StacksMixin:
                 self.args.parent_stack_id,
             ],
             attempts=2,
+            allow_not_found=True,
         )
         stack = result.get("data", result)
+        if not resource_id(stack):
+            LOGGER.info(
+                "Parent Resource Manager stack %s is already absent",
+                self.args.parent_stack_id,
+            )
+            return
         if not is_owned(stack):
             LOGGER.warning(
                 "Preserving explicitly supplied parent stack %s because it "

--- a/oci-integration-cleanup/oci_cleanup/domains/stacks.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/stacks.py
@@ -20,6 +20,7 @@ from ..resources import (
     exact_owned,
     is_owned,
     lifecycle_state,
+    resource_compartment,
     resource_field,
     resource_id,
     resource_name,
@@ -116,6 +117,7 @@ class StacksMixin:
         *,
         action_prefix: str,
         stack_kind: str,
+        requires_confirmation: bool = False,
     ) -> bool:
         stack_id = resource_id(stack)
         name = resource_name(stack)
@@ -130,6 +132,9 @@ class StacksMixin:
             "error_code": None,
             "deletion_message": description,
         }
+        if requires_confirmation:
+            action["requires_confirmation"] = True
+            action["confirmation_reason"] = "missing ownedby=datadog tag"
         self.planned.append(action)
         if not self.execute:
             return True
@@ -243,13 +248,41 @@ class StacksMixin:
         )
         for stack in stacks:
             name = resource_name(stack)
-            if name.startswith(REGIONAL_STACK_PREFIX) and exact_owned(
+            if not name.startswith(REGIONAL_STACK_PREFIX):
+                continue
+            if resource_compartment(stack) != context.compartment_id:
+                continue
+            if exact_owned(
                 stack,
                 expected_names={name},
                 compartment_id=context.compartment_id,
             ):
                 self.destroy_regional_stack(region, stack)
-
+                continue
+            if not self.execute:
+                self._destroy_stack(
+                    region,
+                    stack,
+                    action_prefix="regional-stack",
+                    stack_kind="regional",
+                    requires_confirmation=True,
+                )
+                continue
+            LOGGER.warning(
+                "Regional stack %s (%s) in %s has the expected Datadog name "
+                "but no ownedby=datadog tag",
+                name,
+                resource_id(stack),
+                region,
+            )
+            if self._ask_yes_no(f"Delete this untagged regional stack {name}?"):
+                self.destroy_regional_stack(region, stack)
+            else:
+                self._record_failure(
+                    "Untagged regional stack deletion was not approved",
+                    resource_id=resource_id(stack),
+                    region=region,
+                )
 
     def cleanup_parent_stack(self, context: CleanupContext) -> None:
         if not self.args.parent_stack_id:
@@ -276,12 +309,29 @@ class StacksMixin:
             )
             return
         if not is_owned(stack):
+            name = resource_name(stack) or self.args.parent_stack_id
+            if not self.execute:
+                self._destroy_stack(
+                    context.home_region,
+                    stack,
+                    action_prefix="parent-stack",
+                    stack_kind="parent",
+                    requires_confirmation=True,
+                )
+                return
             LOGGER.warning(
-                "Preserving explicitly supplied parent stack %s because it "
-                "does not have the ownedby=datadog tag",
+                "Explicitly supplied parent stack %s (%s) has no "
+                "ownedby=datadog tag",
+                name,
                 self.args.parent_stack_id,
             )
-            return
+            if not self._ask_yes_no(f"Delete this untagged parent stack {name}?"):
+                self._record_failure(
+                    "Untagged parent stack deletion was not approved",
+                    resource_id=resource_id(stack),
+                    region=context.home_region,
+                )
+                return
         self._destroy_stack(
             context.home_region,
             stack,

--- a/oci-integration-cleanup/oci_cleanup/domains/stacks.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/stacks.py
@@ -15,19 +15,30 @@ from typing import Any
 from ..constants import LOGGER, REGIONAL_STACK_PREFIX
 from ..errors import CleanupError, raw_error_message
 from ..models import CleanupContext
-from ..resources import lifecycle_state, resource_id, resource_name
+from ..resources import (
+    exact_owned,
+    is_owned,
+    lifecycle_state,
+    resource_id,
+    resource_name,
+)
 
 
 class StacksMixin:
     """Destroy validated regional and parent Resource Manager stacks."""
 
-    def destroy_regional_stack(
-        self, region: str, stack: dict[str, Any]
+    def _destroy_stack(
+        self,
+        region: str,
+        stack: dict[str, Any],
+        *,
+        action_prefix: str,
+        stack_kind: str,
     ) -> bool:
         stack_id = resource_id(stack)
         name = resource_name(stack)
-        action_id = f"regional-stack:{region}:{stack_id}"
-        description = f"Destroy and delete regional stack {name} ({stack_id})"
+        action_id = f"{action_prefix}:{region}:{stack_id}"
+        description = f"Destroy and delete {stack_kind} stack {name} ({stack_id})"
         if self.manifest.completed(action_id):
             return True
         self.planned.append(
@@ -66,7 +77,8 @@ class StacksMixin:
             state = lifecycle_state(job)
             if state != "SUCCEEDED":
                 raise CleanupError(
-                    f"Regional destroy job for {stack_id} ended in {state or 'UNKNOWN'}"
+                    f"{stack_kind.capitalize()} destroy job for {stack_id} "
+                    f"ended in {state or 'UNKNOWN'}"
                 )
             self.oci.run(
                 [
@@ -113,6 +125,16 @@ class StacksMixin:
             self.manifest.save()
             return False
 
+    def destroy_regional_stack(
+        self, region: str, stack: dict[str, Any]
+    ) -> bool:
+        return self._destroy_stack(
+            region,
+            stack,
+            action_prefix="regional-stack",
+            stack_kind="regional",
+        )
+
     def cleanup_regional_stacks(
         self, context: CleanupContext, region: str
     ) -> None:
@@ -127,7 +149,12 @@ class StacksMixin:
             ],
         )
         for stack in stacks:
-            if resource_name(stack).startswith(REGIONAL_STACK_PREFIX):
+            name = resource_name(stack)
+            if name.startswith(REGIONAL_STACK_PREFIX) and exact_owned(
+                stack,
+                expected_names={name},
+                compartment_id=context.compartment_id,
+            ):
                 self.destroy_regional_stack(region, stack)
 
 
@@ -135,10 +162,31 @@ class StacksMixin:
         if not self.args.parent_stack_id:
             return
         LOGGER.info("Checking explicitly supplied parent Resource Manager stack")
-        stack = {
-            "id": self.args.parent_stack_id,
-            "display-name": "explicit parent stack",
-        }
-        self.destroy_regional_stack(context.home_region, stack)
+        result = self.oci.run(
+            [
+                "--region",
+                context.home_region,
+                "resource-manager",
+                "stack",
+                "get",
+                "--stack-id",
+                self.args.parent_stack_id,
+            ],
+            attempts=2,
+        )
+        stack = result.get("data", result)
+        if not is_owned(stack):
+            LOGGER.warning(
+                "Preserving explicitly supplied parent stack %s because it "
+                "does not have the ownedby=datadog tag",
+                self.args.parent_stack_id,
+            )
+            return
+        self._destroy_stack(
+            context.home_region,
+            stack,
+            action_prefix="parent-stack",
+            stack_kind="parent",
+        )
 
 

--- a/oci-integration-cleanup/oci_cleanup/domains/stacks.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/stacks.py
@@ -1,0 +1,149 @@
+"""Responsibility: destroy regional and explicitly selected parent Resource Manager stacks.
+
+Safety boundary: preserves failed stacks for retry and only accepts constrained stack identities.
+Cleanup sequence role: handles regional stacks before orphan services and the parent near the end.
+
+``StacksMixin`` validates region-prefixed child stacks and the selected parent stack,
+starts Resource Manager destroy jobs, and checks terminal job status. A stack is
+recorded complete only after a successful destroy, leaving failures resumable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..constants import LOGGER, REGIONAL_STACK_PREFIX
+from ..errors import CleanupError, raw_error_message
+from ..models import CleanupContext
+from ..resources import resource_id, resource_name
+
+
+class StacksMixin:
+    """Destroy validated regional and parent Resource Manager stacks."""
+
+    def destroy_regional_stack(
+        self, region: str, stack: dict[str, Any]
+    ) -> bool:
+        stack_id = resource_id(stack)
+        name = resource_name(stack)
+        action_id = f"regional-stack:{region}:{stack_id}"
+        description = f"Destroy and delete regional stack {name} ({stack_id})"
+        if self.manifest.completed(action_id):
+            return True
+        self.planned.append(
+            {
+                "id": action_id,
+                "description": description,
+                "status": "planned" if not self.execute else "running",
+            }
+        )
+        if not self.execute:
+            self.manifest.record_action(action_id, description, "planned")
+            return True
+
+        self.manifest.record_action(action_id, description, "running")
+        self.manifest.save()
+        try:
+            result = self.oci.run(
+                [
+                    "--region",
+                    region,
+                    "resource-manager",
+                    "job",
+                    "create-destroy-job",
+                    "--stack-id",
+                    stack_id,
+                    "--execution-plan-strategy",
+                    "AUTO_APPROVED",
+                    "--wait-for-state",
+                    "SUCCEEDED",
+                    "--wait-for-state",
+                    "FAILED",
+                ],
+                attempts=2,
+            )
+            job = result.get("data", result)
+            state = str(
+                job.get("lifecycle-state")
+                or job.get("lifecycle_state")
+                or job.get("state")
+                or ""
+            ).upper()
+            if state != "SUCCEEDED":
+                raise CleanupError(
+                    f"Regional destroy job for {stack_id} ended in {state or 'UNKNOWN'}"
+                )
+            self.oci.run(
+                [
+                    "--region",
+                    region,
+                    "resource-manager",
+                    "stack",
+                    "delete",
+                    "--stack-id",
+                    stack_id,
+                    "--force",
+                    "--wait-for-state",
+                    "DELETED",
+                ],
+                attempts=2,
+                allow_not_found=True,
+            )
+            self.manifest.record_action(
+                action_id,
+                description,
+                "completed",
+                destroy_job_id=resource_id(job),
+            )
+            self.manifest.save()
+            return True
+        except Exception as error:
+            # Preserve the stack and its state. Direct orphan cleanup can still
+            # proceed, but the failure remains visible and prevents IAM teardown.
+            message = f"{description}: {error}"
+            raw_error = raw_error_message(error)
+            self.failures.append(message)
+            self.manifest.record_action(
+                action_id,
+                description,
+                "failed",
+                error=str(error),
+                raw_error=raw_error,
+            )
+            self.manifest.record_error(
+                message,
+                action_id,
+                raw_error=raw_error,
+            )
+            self.manifest.save()
+            return False
+
+    def cleanup_regional_stacks(
+        self, context: CleanupContext, region: str
+    ) -> None:
+        stacks = self._list_region(
+            region,
+            [
+                "resource-manager",
+                "stack",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+            ],
+        )
+        for stack in stacks:
+            if resource_name(stack).startswith(REGIONAL_STACK_PREFIX):
+                self.destroy_regional_stack(region, stack)
+
+
+    def cleanup_parent_stack(self, context: CleanupContext) -> None:
+        if not self.args.parent_stack_id:
+            return
+        LOGGER.info("Checking explicitly supplied parent Resource Manager stack")
+        stack = {
+            "id": self.args.parent_stack_id,
+            "display-name": "explicit parent stack",
+        }
+        self.destroy_regional_stack(context.home_region, stack)
+
+

--- a/oci-integration-cleanup/oci_cleanup/domains/stacks.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/stacks.py
@@ -188,5 +188,3 @@ class StacksMixin:
             action_prefix="parent-stack",
             stack_kind="parent",
         )
-
-

--- a/oci-integration-cleanup/oci_cleanup/domains/stacks.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/stacks.py
@@ -15,7 +15,7 @@ from typing import Any
 from ..constants import LOGGER, REGIONAL_STACK_PREFIX
 from ..errors import CleanupError, raw_error_message
 from ..models import CleanupContext
-from ..resources import resource_id, resource_name
+from ..resources import lifecycle_state, resource_id, resource_name
 
 
 class StacksMixin:
@@ -63,12 +63,7 @@ class StacksMixin:
                 attempts=2,
             )
             job = result.get("data", result)
-            state = str(
-                job.get("lifecycle-state")
-                or job.get("lifecycle_state")
-                or job.get("state")
-                or ""
-            ).upper()
+            state = lifecycle_state(job)
             if state != "SUCCEEDED":
                 raise CleanupError(
                     f"Regional destroy job for {stack_id} ended in {state or 'UNKNOWN'}"

--- a/oci-integration-cleanup/oci_cleanup/domains/tags.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/tags.py
@@ -1,0 +1,126 @@
+"""Responsibility: remove the Datadog-managed tag definition and namespace.
+
+Safety boundary: deletes only the exact expected namespace and marker after IAM succeeds.
+Cleanup sequence role: runs after identity cleanup and before parent stack and compartment handling.
+
+``TagsMixin.cleanup_tags`` locates the expected namespace and definition, verifies
+their names and ownership evidence, deletes the definition first, and then removes
+the now-empty namespace through the shared action recorder.
+"""
+
+from __future__ import annotations
+
+from ..constants import LOGGER, TAG_NAME, TAG_NAMESPACE_NAME
+from ..models import CleanupContext
+from ..resources import exact_owned, resource_id, resource_name
+
+
+class TagsMixin:
+    """Remove the Quickstart tag definition and namespace."""
+
+    def cleanup_tags(self, context: CleanupContext) -> None:
+        LOGGER.info("Stage 4/5: cleaning Datadog tag definitions")
+        namespaces = self.oci.list(
+            [
+                "--region",
+                context.home_region,
+                "iam",
+                "tag-namespace",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+                "--include-subcompartments",
+                "false",
+            ]
+        )
+        for namespace in namespaces:
+            if not exact_owned(
+                namespace,
+                expected_names={TAG_NAMESPACE_NAME},
+                compartment_id=context.compartment_id,
+            ):
+                continue
+            namespace_id = resource_id(namespace)
+            tags = self.oci.list(
+                [
+                    "--region",
+                    context.home_region,
+                    "iam",
+                    "tag",
+                    "list",
+                    "--tag-namespace-id",
+                    namespace_id,
+                ]
+            )
+            for tag in tags:
+                if resource_name(tag) != TAG_NAME:
+                    continue
+                tag_id = resource_id(tag)
+                self.action(
+                    f"tag-retire:{tag_id}",
+                    f"Retire {TAG_NAMESPACE_NAME}.{TAG_NAME}",
+                    command=[
+                        "--region",
+                        context.home_region,
+                        "iam",
+                        "tag",
+                        "retire",
+                        "--tag-namespace-id",
+                        namespace_id,
+                        "--tag-name",
+                        TAG_NAME,
+                    ],
+                )
+                self.action(
+                    f"tag-delete:{tag_id}",
+                    f"Delete {TAG_NAMESPACE_NAME}.{TAG_NAME}",
+                    command=[
+                        "--region",
+                        context.home_region,
+                        "iam",
+                        "tag",
+                        "delete",
+                        "--tag-namespace-id",
+                        namespace_id,
+                        "--tag-name",
+                        TAG_NAME,
+                        "--force",
+                        "--wait-for-state",
+                        "SUCCEEDED",
+                        "--wait-for-state",
+                        "FAILED",
+                    ],
+                )
+            self.action(
+                f"tag-namespace-retire:{namespace_id}",
+                f"Retire tag namespace {TAG_NAMESPACE_NAME}",
+                command=[
+                    "--region",
+                    context.home_region,
+                    "iam",
+                    "tag-namespace",
+                    "retire",
+                    "--tag-namespace-id",
+                    namespace_id,
+                ],
+            )
+            self.action(
+                f"tag-namespace-delete:{namespace_id}",
+                f"Delete tag namespace {TAG_NAMESPACE_NAME}",
+                command=[
+                    "--region",
+                    context.home_region,
+                    "iam",
+                    "tag-namespace",
+                    "delete",
+                    "--tag-namespace-id",
+                    namespace_id,
+                    "--force",
+                    "--wait-for-state",
+                    "SUCCEEDED",
+                    "--wait-for-state",
+                    "FAILED",
+                ],
+            )
+
+

--- a/oci-integration-cleanup/oci_cleanup/domains/tags.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/tags.py
@@ -122,5 +122,3 @@ class TagsMixin:
                     "FAILED",
                 ],
             )
-
-

--- a/oci-integration-cleanup/oci_cleanup/engine.py
+++ b/oci-integration-cleanup/oci_cleanup/engine.py
@@ -18,6 +18,15 @@ from .constants import LOGGER
 class EngineMixin:
     """Coordinate the complete cleanup sequence for the assembled engine."""
 
+    def _preserve(self, action_id: str, description: str) -> None:
+        self.planned.append(
+            {
+                "id": action_id,
+                "description": description,
+                "status": "blocked",
+            }
+        )
+
     def run(self) -> int:
         LOGGER.info(
             "Starting Datadog OCI cleanup in %s mode",
@@ -59,14 +68,9 @@ class EngineMixin:
             # Keep IAM and credentials so failed child-stack destroy jobs can be
             # retried and declined extra resources remain usable. This is safer
             # than partially removing authorization.
-            self.planned.append(
-                {
-                    "id": "home-identity",
-                    "description": (
-                        "Preserve IAM because cleanup has unresolved failures"
-                    ),
-                    "status": "blocked",
-                }
+            self._preserve(
+                "home-identity",
+                "Preserve IAM because cleanup has unresolved failures",
             )
         else:
             self.cleanup_home_identity(context)
@@ -78,20 +82,14 @@ class EngineMixin:
             self.delete_compartment(context)
         else:
             if self.args.parent_stack_id:
-                self.planned.append(
-                    {
-                        "id": "parent-stack",
-                        "description": "Preserve parent stack because cleanup has failures",
-                        "status": "blocked",
-                    }
+                self._preserve(
+                    "parent-stack",
+                    "Preserve parent stack because cleanup has failures",
                 )
             if self.args.delete_compartment:
-                self.planned.append(
-                    {
-                        "id": "compartment",
-                        "description": "Preserve compartment because cleanup has failures",
-                        "status": "blocked",
-                    }
+                self._preserve(
+                    "compartment",
+                    "Preserve compartment because cleanup has failures",
                 )
 
         summary = {

--- a/oci-integration-cleanup/oci_cleanup/engine.py
+++ b/oci-integration-cleanup/oci_cleanup/engine.py
@@ -1,7 +1,10 @@
 """Responsibility: coordinate the complete cleanup sequence for the assembled engine.
 
-Based off the number of workers supplied, the engine will orchestrate the cleanup of the
-regions in parallel by calling the cleanup region function detailed in region.py.
+Safety boundary: withholds IAM and container teardown whenever regional or confirmation failures remain.
+Cleanup sequence role: drives discovery, confirmations, regional work, IAM, tags, stacks, and compartment cleanup.
+
+``EngineMixin.run`` is the stage orchestrator, including concurrent regional jobs
+and the fail-closed transition to tenancy-wide teardown.
 """
 
 from __future__ import annotations
@@ -51,6 +54,45 @@ class EngineMixin:
                 }
                 for future in as_completed(futures):
                     future.result()
+
+        if self.failures:
+            # Keep IAM and credentials so failed child-stack destroy jobs can be
+            # retried and declined extra resources remain usable. This is safer
+            # than partially removing authorization.
+            self.planned.append(
+                {
+                    "id": "home-identity",
+                    "description": (
+                        "Preserve IAM because cleanup has unresolved failures"
+                    ),
+                    "status": "blocked",
+                }
+            )
+        else:
+            self.cleanup_home_identity(context)
+            if not self.failures:
+                self.cleanup_tags(context)
+
+        if not self.failures:
+            self.cleanup_parent_stack(context)
+            self.delete_compartment(context)
+        else:
+            if self.args.parent_stack_id:
+                self.planned.append(
+                    {
+                        "id": "parent-stack",
+                        "description": "Preserve parent stack because cleanup has failures",
+                        "status": "blocked",
+                    }
+                )
+            if self.args.delete_compartment:
+                self.planned.append(
+                    {
+                        "id": "compartment",
+                        "description": "Preserve compartment because cleanup has failures",
+                        "status": "blocked",
+                    }
+                )
 
         summary = {
             "mode": "execute" if self.execute else "dry-run",

--- a/oci-integration-cleanup/oci_cleanup/region.py
+++ b/oci-integration-cleanup/oci_cleanup/region.py
@@ -1,4 +1,12 @@
-"""Coordinate and isolate per-region cleanup failures."""
+"""Responsibility: coordinate and isolate per-region cleanup failures.
+
+Safety boundary: preserves dependency order and records failures without unsafe IAM teardown.
+Cleanup sequence role: dispatches stacks, services, network, and KMS for each region.
+
+``cleanup_region`` defines the regional dependency chain from child stacks through
+forwarding services and network to KMS. ``_cleanup_region_safely`` captures exceptions
+per region so concurrent work completes while the engine retains a failure barrier.
+"""
 
 from __future__ import annotations
 
@@ -10,6 +18,9 @@ class RegionMixin:
     """Coordinate cleanup and failure isolation for each region."""
 
     def cleanup_region(self, context: CleanupContext, region: str) -> None:
+        LOGGER.info("Stage 2/5: cleaning regional resources in %s", region)
+        LOGGER.info("[%s] Checking Resource Manager child stacks", region)
+        self.cleanup_regional_stacks(context, region)
         LOGGER.info("[%s] Checking connectors, event rules, and streams", region)
         self.cleanup_connectors_events_streams(context, region)
         LOGGER.info("[%s] Checking Object Storage buckets", region)

--- a/oci-integration-cleanup/tests/test_integration_cleanup.py
+++ b/oci-integration-cleanup/tests/test_integration_cleanup.py
@@ -1513,6 +1513,93 @@ class CleanupTestCase(unittest.TestCase):
         )
         self.assertEqual("DELETED", stack_delete[-1])
 
+    def test_regional_stack_cleanup_requires_exact_ownership(self):
+        oci = FakeOci()
+        oci.add_list(
+            "resource-manager stack list",
+            [
+                owned(
+                    {
+                        "id": "owned-stack",
+                        "display-name": "datadog-regional-stack-owned",
+                        "compartment-id": COMPARTMENT,
+                    }
+                ),
+                {
+                    "id": "untagged-stack",
+                    "display-name": "datadog-regional-stack-customer",
+                    "compartment-id": COMPARTMENT,
+                },
+                owned(
+                    {
+                        "id": "wrong-name",
+                        "display-name": "customer-stack",
+                        "compartment-id": COMPARTMENT,
+                    }
+                ),
+                owned(
+                    {
+                        "id": "wrong-compartment",
+                        "display-name": "datadog-regional-stack-other",
+                        "compartment-id": "customer-compartment",
+                    }
+                ),
+            ],
+        )
+        cleaner = self.make_cleaner(oci=oci)
+
+        cleaner.cleanup_regional_stacks(context(), HOME_REGION)
+
+        self.assertEqual(
+            [f"regional-stack:{HOME_REGION}:owned-stack"],
+            [action["id"] for action in cleaner.planned],
+        )
+
+    def test_parent_stack_cleanup_requires_ownership_and_distinct_action_id(self):
+        oci = FakeOci()
+        oci.add_run(
+            "resource-manager stack get",
+            {
+                "data": owned(
+                    {
+                        "id": "parent-stack",
+                        "display-name": "Datadog Forwarding Infrastructure",
+                    }
+                )
+            },
+        )
+        cleaner = self.make_cleaner(
+            oci=oci,
+            args=argparse.Namespace(parent_stack_id="parent-stack"),
+        )
+
+        cleaner.cleanup_parent_stack(context())
+
+        self.assertEqual(
+            [f"parent-stack:{HOME_REGION}:parent-stack"],
+            [action["id"] for action in cleaner.planned],
+        )
+
+    def test_parent_stack_cleanup_preserves_unowned_stack(self):
+        oci = FakeOci()
+        oci.add_run(
+            "resource-manager stack get",
+            {
+                "data": {
+                    "id": "customer-stack",
+                    "display-name": "Customer Infrastructure",
+                }
+            },
+        )
+        cleaner = self.make_cleaner(
+            oci=oci,
+            args=argparse.Namespace(parent_stack_id="customer-stack"),
+        )
+
+        cleaner.cleanup_parent_stack(context())
+
+        self.assertEqual([], cleaner.planned)
+
     def test_compartment_deletion_refuses_residual_or_child_resources(self):
         oci = FakeOci()
         oci.add_list(

--- a/oci-integration-cleanup/tests/test_integration_cleanup.py
+++ b/oci-integration-cleanup/tests/test_integration_cleanup.py
@@ -730,7 +730,10 @@ class CleanupTestCase(unittest.TestCase):
         self.assertEqual(1, len(validated))
         self.assertEqual(cleanup.CONNECTOR_GROUP_NAME, cleanup.resource_name(validated[0][1]))
         self.assertTrue(
-            any("manual review required" in failure for failure in cleaner.failures)
+            any(
+                "manual review required" in failure["message"]
+                for failure in cleaner.failures
+            )
         )
 
     def test_functions_cleanup_preserves_customer_application(self):
@@ -1470,33 +1473,175 @@ class CleanupTestCase(unittest.TestCase):
         self.assertEqual(1, len(api_key_calls))
         self.assertIn('user.value eq "scim-user"', api_key_calls[0])
 
-    def test_failed_regional_destroy_preserves_stack_and_records_failure(self):
+    def test_failed_regional_destroy_records_structured_failure(self):
         oci = FakeOci()
+        oci.add_list("resource-manager job list", [])
         oci.add_run(
             "create-destroy-job",
-            {"data": {"id": "job", "lifecycle-state": "FAILED"}},
+            {
+                "data": {
+                    "id": "job",
+                    "lifecycle-state": "FAILED",
+                    "failure-details": {
+                        "code": "TerraformError",
+                        "message": "provider failed",
+                    },
+                }
+            },
         )
         cleaner = self.make_cleaner(execute=True, oci=oci)
         result = cleaner.destroy_regional_stack(
             HOME_REGION,
-            {"id": "stack", "display-name": "datadog-regional-stack-test"},
+            {
+                "id": "ocid1.ormstack.oc1..stack",
+                "display-name": "datadog-regional-stack-test",
+            },
         )
         self.assertFalse(result)
         self.assertFalse(
             any("stack delete" in " ".join(call) for call in oci.run_calls)
         )
+        self.assertEqual("failed", cleaner.planned[0]["status"])
         self.assertEqual(
-            "failed",
-            cleaner.manifest.data["actions"][
-                f"regional-stack:{HOME_REGION}:stack"
-            ]["status"],
+            {
+                "message": (
+                    "Regional destroy job for ocid1.ormstack.oc1..stack "
+                    "ended in FAILED"
+                ),
+                "resource_id": "ocid1.ormstack.oc1..stack",
+                "region": HOME_REGION,
+                "error_code": "TerraformError",
+                "deletion_message": "provider failed",
+            },
+            cleaner.failures[0],
         )
 
-    def test_successful_regional_destroy_waits_for_stack_deleted(self):
+    def test_dry_run_stack_teardown_does_not_mutate_or_reconcile_jobs(self):
         oci = FakeOci()
+        cleaner = self.make_cleaner(oci=oci)
+
+        self.assertTrue(
+            cleaner.destroy_regional_stack(
+                HOME_REGION,
+                {"id": "stack", "display-name": "datadog-regional-stack-test"},
+            )
+        )
+
+        self.assertEqual([], oci.list_calls)
+        self.assertEqual([], oci.run_calls)
+        self.assertEqual("planned", cleaner.planned[0]["status"])
+
+    def test_in_progress_destroy_is_waited_without_duplicate_create(self):
+        oci = FakeOci()
+        oci.add_list(
+            "resource-manager job list",
+            [
+                {
+                    "id": "older-destroy",
+                    "operation": "DESTROY",
+                    "lifecycle-state": "SUCCEEDED",
+                    "time-created": "2026-08-17T10:00:00Z",
+                },
+                {
+                    "id": "newer-apply",
+                    "operation": "APPLY",
+                    "lifecycle-state": "IN_PROGRESS",
+                    "time-created": "2026-08-18T12:00:00Z",
+                },
+                {
+                    "id": "active-destroy",
+                    "operation": "DESTROY",
+                    "lifecycle-state": "IN_PROGRESS",
+                    "time_created": "2026-08-18T11:00:00+00:00",
+                },
+            ],
+        )
+        oci.add_run(
+            "resource-manager job get",
+            {"data": {"id": "active-destroy", "lifecycle-state": "SUCCEEDED"}},
+        )
+        cleaner = self.make_cleaner(execute=True, oci=oci)
+
+        self.assertTrue(
+            cleaner.destroy_regional_stack(
+                HOME_REGION,
+                {"id": "stack", "display-name": "datadog-regional-stack-test"},
+            )
+        )
+
+        job_list = next(call for call in oci.list_calls if "job" in call)
+        self.assertEqual(
+            [
+                "--region",
+                HOME_REGION,
+                "resource-manager",
+                "job",
+                "list",
+                "--stack-id",
+                "stack",
+            ],
+            job_list,
+        )
+        job_get = next(
+            call for call in oci.run_calls if "get" in call and "job" in call
+        )
+        self.assertIn("active-destroy", job_get)
+        self.assertIn("SUCCEEDED", job_get)
+        self.assertIn("FAILED", job_get)
+        self.assertFalse(
+            any("create-destroy-job" in call for call in oci.run_calls)
+        )
+
+    def test_in_progress_destroy_that_fails_is_retried_once(self):
+        oci = FakeOci()
+        oci.add_list(
+            "resource-manager job list",
+            [
+                {
+                    "id": "active-destroy",
+                    "operation": "DESTROY",
+                    "lifecycle-state": "IN_PROGRESS",
+                    "time-created": "2026-08-18T12:00:00Z",
+                }
+            ],
+        )
+        oci.add_run(
+            "resource-manager job get",
+            {"data": {"id": "active-destroy", "lifecycle-state": "FAILED"}},
+        )
         oci.add_run(
             "create-destroy-job",
-            {"data": {"id": "job", "lifecycle-state": "SUCCEEDED"}},
+            {"data": {"id": "retry-job", "lifecycle-state": "SUCCEEDED"}},
+        )
+        cleaner = self.make_cleaner(execute=True, oci=oci)
+
+        self.assertTrue(
+            cleaner.destroy_regional_stack(
+                HOME_REGION,
+                {"id": "stack", "display-name": "datadog-regional-stack-test"},
+            )
+        )
+        self.assertEqual(
+            1,
+            sum("create-destroy-job" in call for call in oci.run_calls),
+        )
+        job_get = next(
+            call for call in oci.run_calls if "get" in call and "job" in call
+        )
+        self.assertIn("CANCELED", job_get)
+
+    def test_succeeded_destroy_job_is_reused_and_stack_record_deleted(self):
+        oci = FakeOci()
+        oci.add_list(
+            "resource-manager job list",
+            [
+                {
+                    "id": "completed-destroy",
+                    "operation": "DESTROY",
+                    "lifecycle-state": "SUCCEEDED",
+                    "time-created": "2026-08-18T12:00:00Z",
+                }
+            ],
         )
         cleaner = self.make_cleaner(execute=True, oci=oci)
 
@@ -1506,12 +1651,47 @@ class CleanupTestCase(unittest.TestCase):
         )
 
         self.assertTrue(result)
+        self.assertFalse(
+            any("create-destroy-job" in call for call in oci.run_calls)
+        )
         stack_delete = next(
             call
             for call in oci.run_calls
             if "stack" in call and "delete" in call
         )
         self.assertEqual("DELETED", stack_delete[-1])
+        delete_kwargs = oci.run_kwargs[oci.run_calls.index(stack_delete)]
+        self.assertTrue(delete_kwargs["allow_not_found"])
+
+    def test_failed_destroy_job_is_retried_with_new_destroy(self):
+        oci = FakeOci()
+        oci.add_list(
+            "resource-manager job list",
+            [
+                {
+                    "id": "failed-destroy",
+                    "operation": "DESTROY",
+                    "lifecycle-state": "FAILED",
+                    "time-created": "2026-08-18T12:00:00Z",
+                }
+            ],
+        )
+        oci.add_run(
+            "create-destroy-job",
+            {"data": {"id": "retry-job", "lifecycle-state": "SUCCEEDED"}},
+        )
+        cleaner = self.make_cleaner(execute=True, oci=oci)
+
+        self.assertTrue(
+            cleaner.destroy_regional_stack(
+                HOME_REGION,
+                {"id": "stack", "display-name": "datadog-regional-stack-test"},
+            )
+        )
+        creates = [
+            call for call in oci.run_calls if "create-destroy-job" in call
+        ]
+        self.assertEqual(1, len(creates))
 
     def test_regional_stack_cleanup_requires_exact_ownership(self):
         oci = FakeOci()
@@ -1580,6 +1760,64 @@ class CleanupTestCase(unittest.TestCase):
             [action["id"] for action in cleaner.planned],
         )
 
+    def test_parent_stack_cleanup_treats_missing_stack_as_complete(self):
+        oci = FakeOci()
+        cleaner = self.make_cleaner(
+            execute=True,
+            oci=oci,
+            args=argparse.Namespace(parent_stack_id="missing-stack"),
+        )
+
+        cleaner.cleanup_parent_stack(context())
+
+        self.assertEqual([], cleaner.planned)
+        self.assertEqual([], cleaner.failures)
+        self.assertEqual(
+            {"attempts": 2, "allow_not_found": True},
+            oci.run_kwargs[0],
+        )
+
+    def test_in_progress_parent_destroy_job_is_waited(self):
+        oci = FakeOci()
+        oci.add_run(
+            "resource-manager stack get",
+            {
+                "data": owned(
+                    {
+                        "id": "parent-stack",
+                        "display-name": "Datadog Forwarding Infrastructure",
+                    }
+                )
+            },
+        )
+        oci.add_list(
+            "resource-manager job list",
+            [
+                {
+                    "id": "parent-destroy",
+                    "operation": "DESTROY",
+                    "lifecycle-state": "ACCEPTED",
+                    "time-created": "2026-08-18T12:00:00Z",
+                }
+            ],
+        )
+        oci.add_run(
+            "resource-manager job get",
+            {"data": {"id": "parent-destroy", "lifecycle-state": "SUCCEEDED"}},
+        )
+        cleaner = self.make_cleaner(
+            execute=True,
+            oci=oci,
+            args=argparse.Namespace(parent_stack_id="parent-stack"),
+        )
+
+        cleaner.cleanup_parent_stack(context())
+
+        self.assertTrue(any("job" in call and "get" in call for call in oci.run_calls))
+        self.assertFalse(
+            any("create-destroy-job" in call for call in oci.run_calls)
+        )
+
     def test_parent_stack_cleanup_preserves_unowned_stack(self):
         oci = FakeOci()
         oci.add_run(
@@ -1632,8 +1870,13 @@ class CleanupTestCase(unittest.TestCase):
         )
         cleaner.delete_compartment(context(compartment=tagged_compartment))
         self.assertTrue(
-            any("Compartment preserved" in failure for failure in cleaner.failures)
+            any(
+                "Compartment preserved" in failure["message"]
+                for failure in cleaner.failures
+            )
         )
+        self.assertEqual(COMPARTMENT, cleaner.failures[0]["resource_id"])
+        self.assertEqual(HOME_REGION, cleaner.failures[0]["region"])
         self.assertFalse(
             any(action["id"].startswith("compartment:") for action in cleaner.planned)
         )

--- a/oci-integration-cleanup/tests/test_integration_cleanup.py
+++ b/oci-integration-cleanup/tests/test_integration_cleanup.py
@@ -683,6 +683,56 @@ class CleanupTestCase(unittest.TestCase):
             self.assertEqual(value, cleaner.failures[0][key])
             self.assertEqual(value, cleaner.planned[0][key])
 
+    def test_dynamic_group_requires_name_description_rule_and_policy_reference(self):
+        oci = FakeOci()
+        connector_ocid = "ocid1.dynamicresourcegroup.oc1..connector"
+        function_ocid = "ocid1.dynamicresourcegroup.oc1..function"
+        oci.add_list(
+            "identity-domains dynamic-resource-groups list",
+            [
+                {
+                    "id": "connector-scim",
+                    "ocid": connector_ocid,
+                    "display-name": cleanup.CONNECTOR_GROUP_NAME,
+                    "description": cleanup.CONNECTOR_GROUP_DESCRIPTION,
+                    "matching-rule": (
+                        "All {resource.type = 'serviceconnector', "
+                        f"resource.compartment.id = '{COMPARTMENT}'}}"
+                    ),
+                },
+                {
+                    "id": "function-scim",
+                    "ocid": function_ocid,
+                    "display-name": cleanup.FUNCTION_GROUP_NAME,
+                    "description": "wrong description",
+                    "matching-rule": (
+                        "All {resource.type = 'fnfunc', "
+                        f"resource.compartment.id = '{COMPARTMENT}'}}"
+                    ),
+                },
+            ],
+        )
+        cleaner = self.make_cleaner(oci=oci)
+        policy = owned(
+            {
+                "id": "policy",
+                "name": cleanup.DYNAMIC_POLICY_NAME,
+                "compartment-id": TENANCY,
+                "statements": [
+                    f"Allow dynamic-group id {connector_ocid} to read metrics in tenancy",
+                    f"Allow dynamic-group id {function_ocid} to use fn-function in tenancy",
+                ],
+            }
+        )
+        validated = cleaner._validated_dynamic_groups(
+            context(domains=[{"url": "https://identity.example"}]), [policy]
+        )
+        self.assertEqual(1, len(validated))
+        self.assertEqual(cleanup.CONNECTOR_GROUP_NAME, cleanup.resource_name(validated[0][1]))
+        self.assertTrue(
+            any("manual review required" in failure for failure in cleaner.failures)
+        )
+
     def test_functions_cleanup_preserves_customer_application(self):
         oci = FakeOci()
         oci.add_list(
@@ -1385,6 +1435,141 @@ class CleanupTestCase(unittest.TestCase):
         self.assertEqual("DELETED", event_delete[-1])
         self.assertEqual("DELETED", stream_delete[-1])
 
+    def test_identity_cleanup_deletes_keys_only_for_tagged_user(self):
+        oci = FakeOci()
+        oci.add_list(
+            "iam policy list",
+            [],
+        )
+        oci.add_list("identity-domains dynamic-resource-groups list", [])
+        tagged_user = owned({"id": "scim-user", "display-name": cleanup.USER_NAME})
+        untagged_user = {"id": "existing-user", "display-name": cleanup.USER_NAME}
+        oci.add_list("identity-domains users list", [tagged_user, untagged_user])
+        oci.add_list(
+            "identity-domains groups list",
+            [owned({"id": "scim-group", "display-name": cleanup.GROUP_NAME})],
+        )
+        oci.add_list(
+            "identity-domains api-keys list",
+            [{"id": "key-1"}, {"id": "key-2"}],
+        )
+        cleaner = self.make_cleaner(oci=oci)
+        cleaner.cleanup_home_identity(
+            context(domains=[{"url": "https://identity.example"}])
+        )
+        action_ids = {action["id"] for action in cleaner.planned}
+        self.assertIn("api-key:key-1", action_ids)
+        self.assertIn("api-key:key-2", action_ids)
+        self.assertIn("identity-user:scim-user", action_ids)
+        self.assertNotIn("identity-user:existing-user", action_ids)
+        api_key_calls = [
+            " ".join(call)
+            for call in oci.list_calls
+            if "api-keys" in " ".join(call)
+        ]
+        self.assertEqual(1, len(api_key_calls))
+        self.assertIn('user.value eq "scim-user"', api_key_calls[0])
+
+    def test_failed_regional_destroy_preserves_stack_and_records_failure(self):
+        oci = FakeOci()
+        oci.add_run(
+            "create-destroy-job",
+            {"data": {"id": "job", "lifecycle-state": "FAILED"}},
+        )
+        cleaner = self.make_cleaner(execute=True, oci=oci)
+        result = cleaner.destroy_regional_stack(
+            HOME_REGION,
+            {"id": "stack", "display-name": "datadog-regional-stack-test"},
+        )
+        self.assertFalse(result)
+        self.assertFalse(
+            any("stack delete" in " ".join(call) for call in oci.run_calls)
+        )
+        self.assertEqual(
+            "failed",
+            cleaner.manifest.data["actions"][
+                f"regional-stack:{HOME_REGION}:stack"
+            ]["status"],
+        )
+
+    def test_successful_regional_destroy_waits_for_stack_deleted(self):
+        oci = FakeOci()
+        oci.add_run(
+            "create-destroy-job",
+            {"data": {"id": "job", "lifecycle-state": "SUCCEEDED"}},
+        )
+        cleaner = self.make_cleaner(execute=True, oci=oci)
+
+        result = cleaner.destroy_regional_stack(
+            HOME_REGION,
+            {"id": "stack", "display-name": "datadog-regional-stack-test"},
+        )
+
+        self.assertTrue(result)
+        stack_delete = next(
+            call
+            for call in oci.run_calls
+            if "stack" in call and "delete" in call
+        )
+        self.assertEqual("DELETED", stack_delete[-1])
+
+    def test_compartment_deletion_refuses_residual_or_child_resources(self):
+        oci = FakeOci()
+        oci.add_list(
+            "iam compartment list",
+            [{"id": "child", "name": "customer-child", "lifecycle-state": "ACTIVE"}],
+        )
+        oci.add_run(
+            "query all resources where compartmentId",
+            {
+                "data": {
+                    "items": [
+                        {
+                            "identifier": "customer-resource",
+                            "display-name": "customer",
+                            "resource-type": "Instance",
+                            "compartment-id": COMPARTMENT,
+                        }
+                    ]
+                }
+            },
+        )
+        args = argparse.Namespace(delete_compartment=True)
+        cleaner = self.make_cleaner(execute=True, oci=oci, args=args)
+        tagged_compartment = owned(
+            {
+                "id": COMPARTMENT,
+                "name": cleanup.AUTO_COMPARTMENT_NAME,
+                "description": cleanup.AUTO_COMPARTMENT_DESCRIPTION,
+            }
+        )
+        cleaner.delete_compartment(context(compartment=tagged_compartment))
+        self.assertTrue(
+            any("Compartment preserved" in failure for failure in cleaner.failures)
+        )
+        self.assertFalse(
+            any(action["id"].startswith("compartment:") for action in cleaner.planned)
+        )
+
+    def test_dry_run_compartment_deletion_is_conditional(self):
+        args = argparse.Namespace(delete_compartment=True)
+        cleaner = self.make_cleaner(args=args)
+        tagged_compartment = owned(
+            {
+                "id": COMPARTMENT,
+                "name": cleanup.AUTO_COMPARTMENT_NAME,
+                "description": cleanup.AUTO_COMPARTMENT_DESCRIPTION,
+            }
+        )
+        cleaner.delete_compartment(context(compartment=tagged_compartment))
+        action = next(
+            action
+            for action in cleaner.planned
+            if action["id"] == f"compartment:{COMPARTMENT}"
+        )
+        self.assertTrue(action["conditional"])
+        self.assertEqual([], cleaner.failures)
+
     def test_kms_actions_use_minimum_buffered_deletion_times(self):
         before = dt.datetime.now(dt.timezone.utc)
         oci = FakeOci()
@@ -1551,6 +1736,26 @@ class CleanupTestCase(unittest.TestCase):
         self.assertEqual("vault", cleaner.failures[0]["resource_id"])
         self.assertEqual(HOME_REGION, cleaner.failures[0]["region"])
         self.assertIn("no management endpoint", cleaner.failures[0]["message"])
+
+    def test_cleanup_region_dependency_order(self):
+        cleaner = self.make_cleaner()
+        calls = []
+        methods = [
+            "cleanup_regional_stacks",
+            "cleanup_connectors_events_streams",
+            "cleanup_buckets",
+            "cleanup_functions",
+            "cleanup_network",
+            "cleanup_kms",
+        ]
+        for method in methods:
+            setattr(
+                cleaner,
+                method,
+                lambda _context, _region, method=method: calls.append(method),
+            )
+        cleaner.cleanup_region(context(), HOME_REGION)
+        self.assertEqual(methods, calls)
 
     def test_run_cleans_regions_concurrently(self):
         cleaner = self.make_cleaner(

--- a/oci-integration-cleanup/tests/test_integration_cleanup.py
+++ b/oci-integration-cleanup/tests/test_integration_cleanup.py
@@ -1693,7 +1693,7 @@ class CleanupTestCase(unittest.TestCase):
         ]
         self.assertEqual(1, len(creates))
 
-    def test_regional_stack_cleanup_requires_exact_ownership(self):
+    def test_regional_stack_cleanup_plans_confirmation_for_untagged_match(self):
         oci = FakeOci()
         oci.add_list(
             "resource-manager stack list",
@@ -1727,13 +1727,70 @@ class CleanupTestCase(unittest.TestCase):
             ],
         )
         cleaner = self.make_cleaner(oci=oci)
+        cleaner._ask_yes_no = lambda _prompt: self.fail("dry-run prompted")
 
         cleaner.cleanup_regional_stacks(context(), HOME_REGION)
 
         self.assertEqual(
-            [f"regional-stack:{HOME_REGION}:owned-stack"],
+            [
+                f"regional-stack:{HOME_REGION}:owned-stack",
+                f"regional-stack:{HOME_REGION}:untagged-stack",
+            ],
             [action["id"] for action in cleaner.planned],
         )
+        self.assertNotIn("requires_confirmation", cleaner.planned[0])
+        self.assertTrue(cleaner.planned[1]["requires_confirmation"])
+
+    def test_regional_stack_cleanup_prompts_for_untagged_match(self):
+        oci = FakeOci()
+        oci.add_list(
+            "resource-manager stack list",
+            [
+                {
+                    "id": "untagged-stack",
+                    "display-name": "datadog-regional-stack-test",
+                    "compartment-id": COMPARTMENT,
+                }
+            ],
+        )
+        cleaner = self.make_cleaner(execute=True, oci=oci)
+        prompts = []
+        destroyed = []
+        cleaner._ask_yes_no = lambda prompt: prompts.append(prompt) or True
+        cleaner.destroy_regional_stack = (
+            lambda region, stack: destroyed.append((region, stack["id"]))
+        )
+
+        cleaner.cleanup_regional_stacks(context(), HOME_REGION)
+
+        self.assertEqual(
+            [(HOME_REGION, "untagged-stack")],
+            destroyed,
+        )
+        self.assertIn("datadog-regional-stack-test", prompts[0])
+
+    def test_declined_untagged_regional_stack_blocks_final_teardown(self):
+        oci = FakeOci()
+        oci.add_list(
+            "resource-manager stack list",
+            [
+                {
+                    "id": "untagged-stack",
+                    "display-name": "datadog-regional-stack-test",
+                    "compartment-id": COMPARTMENT,
+                }
+            ],
+        )
+        cleaner = self.make_cleaner(execute=True, oci=oci)
+        cleaner._ask_yes_no = lambda _prompt: False
+        cleaner.destroy_regional_stack = lambda _region, _stack: self.fail(
+            "declined stack was destroyed"
+        )
+
+        cleaner.cleanup_regional_stacks(context(), HOME_REGION)
+
+        self.assertEqual("untagged-stack", cleaner.failures[0]["resource_id"])
+        self.assertIn("not approved", cleaner.failures[0]["message"])
 
     def test_parent_stack_cleanup_requires_ownership_and_distinct_action_id(self):
         oci = FakeOci()
@@ -1818,7 +1875,7 @@ class CleanupTestCase(unittest.TestCase):
             any("create-destroy-job" in call for call in oci.run_calls)
         )
 
-    def test_parent_stack_cleanup_preserves_unowned_stack(self):
+    def test_parent_stack_cleanup_plans_confirmation_for_untagged_stack(self):
         oci = FakeOci()
         oci.add_run(
             "resource-manager stack get",
@@ -1833,10 +1890,48 @@ class CleanupTestCase(unittest.TestCase):
             oci=oci,
             args=argparse.Namespace(parent_stack_id="customer-stack"),
         )
+        cleaner._ask_yes_no = lambda _prompt: self.fail("dry-run prompted")
 
         cleaner.cleanup_parent_stack(context())
 
-        self.assertEqual([], cleaner.planned)
+        self.assertEqual(
+            [f"parent-stack:{HOME_REGION}:customer-stack"],
+            [action["id"] for action in cleaner.planned],
+        )
+        self.assertTrue(cleaner.planned[0]["requires_confirmation"])
+
+    def test_parent_stack_cleanup_prompts_for_untagged_stack(self):
+        oci = FakeOci()
+        oci.add_run(
+            "resource-manager stack get",
+            {
+                "data": {
+                    "id": "parent-stack",
+                    "display-name": "Datadog Forwarding Infrastructure",
+                }
+            },
+        )
+        cleaner = self.make_cleaner(
+            execute=True,
+            oci=oci,
+            args=argparse.Namespace(parent_stack_id="parent-stack"),
+        )
+        prompts = []
+        destroyed = []
+        cleaner._ask_yes_no = lambda prompt: prompts.append(prompt) or True
+        cleaner._destroy_stack = (
+            lambda region, stack, **kwargs: destroyed.append(
+                (region, stack["id"], kwargs["stack_kind"])
+            )
+        )
+
+        cleaner.cleanup_parent_stack(context())
+
+        self.assertEqual(
+            [(HOME_REGION, "parent-stack", "parent")],
+            destroyed,
+        )
+        self.assertIn("Datadog Forwarding Infrastructure", prompts[0])
 
     def test_compartment_deletion_refuses_residual_or_child_resources(self):
         oci = FakeOci()


### PR DESCRIPTION
## Summary
- destroy regional Resource Manager stacks before direct orphan cleanup and remove the parent stack last
- remove validated IAM users, groups, policies, dynamic groups, and managed tags only after regional cleanup succeeds
- add guarded compartment teardown as the final cleanup stage: `--delete-compartment` is required, and execution requires `--dry-run false`, a proven Quickstart-created and owned compartment, no residual resources or child compartments, and no pending KMS deletions
- document the complete stateless recovery workflow and safe retry behavior

## Stack
- Depends on https://github.com/DataDog/oracle-cloud-integration/pull/168
- For context on how this package works: [README](https://github.com/DataDog/oracle-cloud-integration/blob/d44f6dd1e62fe0f75c628c2f738e54024d1ede78/oci-integration-cleanup/README.md)

## Test plan
- [x] `python3 -m unittest discover -s oci-integration-cleanup/tests -p 'test_*.py' -v` (64 tests)