### PR TITLE
Discover and approve unexpected cleanup resources

### DIFF
--- a/oci-integration-cleanup/integration_cleanup.py
+++ b/oci-integration-cleanup/integration_cleanup.py
@@ -23,6 +23,7 @@ from oci_cleanup import *  # noqa: F401,F403
 from oci_cleanup import __all__ as package_api
 from oci_cleanup.base import CleanupBase
 from oci_cleanup.discovery import DiscoveryMixin
+from oci_cleanup.domains.extras import ExtrasMixin
 from oci_cleanup.engine import EngineMixin
 from oci_cleanup.region import RegionMixin
 
@@ -32,10 +33,11 @@ __all__ = [*package_api, "QuickstartCleanup", "parse_args", "main"]
 class QuickstartCleanup(
     EngineMixin,
     DiscoveryMixin,
+    ExtrasMixin,
     RegionMixin,
     CleanupBase,
 ):
-    """Discover one Datadog OCI Quickstart installation."""
+    """Discover unexpected resources in one OCI Quickstart installation."""
 
 
 def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:

--- a/oci-integration-cleanup/oci_cleanup/domains/extras.py
+++ b/oci-integration-cleanup/oci_cleanup/domains/extras.py
@@ -1,0 +1,747 @@
+"""Responsibility: discover, confirm, and delete unexpected nested resources.
+
+Safety boundary: fails closed for non-interactive input and persists explicit approvals.
+Cleanup sequence role: runs after discovery and before concurrent regional cleanup.
+
+``ExtrasMixin`` finds unexpected functions, VNIC attachments, and network dependents within 
+the Datadog created function apps and VCN resources and
+turns each into an auditable candidate command, and prompts on every execute run
+while the blocker remains live. Later stages use the current run's decisions to
+delete approved children or preserve their parents.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from ..constants import (
+    FUNCTION_APP_NAME,
+    FUNCTION_NAMES,
+    LOGGER,
+    NAT_GATEWAY_NAME,
+    SERVICE_GATEWAY_NAME,
+    SUBNET_NAME,
+    VCN_NAME,
+)
+from ..errors import CommandError
+from ..models import CleanupContext, ExtraResourceCandidate
+from ..resources import (
+    data_items,
+    defined_marker,
+    exact_owned,
+    is_deleted_or_deleting,
+    is_owned,
+    lifecycle_state,
+    resource_compartment,
+    resource_field,
+    resource_id,
+    resource_name,
+    utc_now,
+)
+
+
+@dataclass(frozen=True)
+class _GatewaySpec:
+    kind: str
+    cli_kind: str
+    id_flag: str
+    expected_owned_name: Optional[str]
+    always_extra: bool
+
+
+class ExtrasMixin:
+    """Manage approval and deletion of unexpected nested resources."""
+
+    def _extra_candidate(
+        self,
+        *,
+        kind: str,
+        resource: dict[str, Any],
+        region: str,
+        container_id: str,
+        container_name: str,
+        impact: str,
+        command: Optional[list[str]],
+        resource_identifier: Optional[str] = None,
+        resource_display_name: Optional[str] = None,
+        requires_compute_confirmation: bool = False,
+        details: Optional[dict[str, Any]] = None,
+    ) -> ExtraResourceCandidate:
+        identifier = resource_identifier or resource_id(resource)
+        return ExtraResourceCandidate(
+            candidate_id=f"extra:{kind}:{region}:{identifier}",
+            kind=kind,
+            resource_id=identifier,
+            name=resource_display_name or resource_name(resource) or identifier,
+            region=region,
+            container_id=container_id,
+            container_name=container_name,
+            impact=impact,
+            command=tuple(command) if command else None,
+            requires_compute_confirmation=requires_compute_confirmation,
+            details=details or {},
+        )
+
+
+    def _compute_compartment_ids(self, context: CleanupContext) -> list[str]:
+        if self._accessible_compartment_ids is not None:
+            return self._accessible_compartment_ids
+        compartments: list[dict[str, Any]] = []
+        try:
+            compartments = self._list_region(
+                context.home_region,
+                [
+                    "iam",
+                    "compartment",
+                    "list",
+                    "--compartment-id",
+                    context.tenancy_id,
+                    "--compartment-id-in-subtree",
+                    "true",
+                    "--access-level",
+                    "ACCESSIBLE",
+                ],
+            )
+        except CommandError as error:
+            LOGGER.warning(
+                "Could not inventory accessible compartments for cross-compartment "
+                "VNIC attachment discovery: %s",
+                error,
+            )
+            return list(
+                dict.fromkeys([context.compartment_id, context.tenancy_id])
+            )
+        identifiers = [
+            resource_id(compartment)
+            for compartment in compartments
+            if resource_id(compartment)
+            and lifecycle_state(compartment) not in {"DELETED", "DELETING"}
+        ]
+        identifiers.extend([context.compartment_id, context.tenancy_id])
+        self._accessible_compartment_ids = list(dict.fromkeys(identifiers))
+        return self._accessible_compartment_ids
+
+    def _find_vnic_attachments(
+        self,
+        context: CleanupContext,
+        region: str,
+        vnic_id: str,
+        preferred_compartment_id: str,
+    ) -> tuple[list[dict[str, Any]], str]:
+        compartment_ids = [
+            preferred_compartment_id,
+            *self._compute_compartment_ids(context),
+        ]
+        for compartment_id in dict.fromkeys(
+            identifier for identifier in compartment_ids if identifier
+        ):
+            try:
+                attachments = self._list_region(
+                    region,
+                    [
+                        "compute",
+                        "vnic-attachment",
+                        "list",
+                        "--compartment-id",
+                        compartment_id,
+                        "--vnic-id",
+                        vnic_id,
+                    ],
+                )
+            except CommandError as error:
+                LOGGER.warning(
+                    "Could not inspect VNIC %s attachments in compartment %s: %s",
+                    vnic_id,
+                    compartment_id,
+                    error,
+                )
+                continue
+            live_attachments = [
+                attachment
+                for attachment in attachments
+                if lifecycle_state(attachment) not in {"DETACHED", "DETACHING"}
+            ]
+            if live_attachments:
+                return live_attachments, compartment_id
+        return [], ""
+
+    def _discover_vnic_extras(
+        self,
+        context: CleanupContext,
+        region: str,
+        subnet: dict[str, Any],
+    ) -> list[ExtraResourceCandidate]:
+        subnet_id = resource_id(subnet)
+        payload = self.oci.run(
+            [
+                "--region",
+                region,
+                "search",
+                "resource",
+                "structured-search",
+                "--query-text",
+                f"query Vnic resources where subnetId = '{subnet_id}'",
+            ],
+            attempts=2,
+        )
+        candidates: list[ExtraResourceCandidate] = []
+        for search_vnic in data_items(payload):
+            vnic_id = resource_id(search_vnic)
+            if not vnic_id:
+                continue
+            vnic_payload = self.oci.run(
+                [
+                    "--region",
+                    region,
+                    "network",
+                    "vnic",
+                    "get",
+                    "--vnic-id",
+                    vnic_id,
+                ],
+                attempts=2,
+                allow_not_found=True,
+            )
+            vnic = vnic_payload.get("data", vnic_payload)
+            if not vnic or str(
+                resource_field(vnic, "subnet-id", "")
+            ) != subnet_id:
+                continue
+            vnic_compartment = resource_compartment(vnic)
+            attachments, instance_compartment = self._find_vnic_attachments(
+                context,
+                region,
+                vnic_id,
+                vnic_compartment,
+            )
+            attachment = attachments[0] if len(attachments) == 1 else None
+            instance_id = str(
+                resource_field(attachment or {}, "instance-id", "")
+            )
+            primary_value = (
+                vnic.get("is-primary")
+                if "is-primary" in vnic
+                else vnic.get("is_primary")
+            )
+            is_primary = (
+                primary_value
+                if isinstance(primary_value, bool)
+                else str(primary_value).lower() == "true"
+            )
+            if not attachment or not instance_id:
+                detach_command = (
+                    [
+                        "--region",
+                        region,
+                        "compute",
+                        "instance",
+                        "detach-vnic",
+                        "--compartment-id",
+                        vnic_compartment,
+                        "--vnic-id",
+                        vnic_id,
+                        "--force",
+                        "--wait-for-state",
+                        "DETACHED",
+                    ]
+                    if vnic_compartment
+                    else None
+                )
+                candidates.append(
+                    self._extra_candidate(
+                        kind=(
+                            "unverified-secondary-vnic"
+                            if detach_command
+                            else "unsupported-vnic"
+                        ),
+                        resource=vnic,
+                        region=region,
+                        container_id=subnet_id,
+                        container_name=SUBNET_NAME,
+                        impact=(
+                            "The VNIC owner could not be identified. If approved, "
+                            "the script will attempt OCI's secondary Compute VNIC "
+                            "detach operation. OCI will reject the request if this "
+                            "is a primary or service-managed VNIC."
+                        ),
+                        command=detach_command,
+                        details={"vnic_id": vnic_id},
+                    )
+                )
+                continue
+            instance_payload = self.oci.run(
+                [
+                    "--region",
+                    region,
+                    "compute",
+                    "instance",
+                    "get",
+                    "--instance-id",
+                    instance_id,
+                ],
+                attempts=2,
+                allow_not_found=True,
+            )
+            instance = instance_payload.get("data", instance_payload)
+            if is_primary:
+                candidates.append(
+                    self._extra_candidate(
+                        kind="compute-instance",
+                        resource=instance or {"id": instance_id},
+                        region=region,
+                        container_id=subnet_id,
+                        container_name=SUBNET_NAME,
+                        impact=(
+                            "This is the primary VNIC. Deleting the dependency "
+                            "terminates the entire Compute instance; its boot "
+                            "volume will be preserved."
+                        ),
+                        command=[
+                            "--region",
+                            region,
+                            "compute",
+                            "instance",
+                            "terminate",
+                            "--instance-id",
+                            instance_id,
+                            "--preserve-boot-volume",
+                            "true",
+                            "--force",
+                            "--wait-for-state",
+                            "SUCCEEDED",
+                        ],
+                        resource_identifier=instance_id,
+                        requires_compute_confirmation=True,
+                        details={"vnic_id": vnic_id, "instance_id": instance_id},
+                    )
+                )
+            else:
+                candidates.append(
+                    self._extra_candidate(
+                        kind="secondary-vnic",
+                        resource=vnic,
+                        region=region,
+                        container_id=subnet_id,
+                        container_name=SUBNET_NAME,
+                        impact=(
+                            "The secondary VNIC will be detached and deleted "
+                            "from its Compute instance."
+                        ),
+                        command=[
+                            "--region",
+                            region,
+                            "compute",
+                            "instance",
+                            "detach-vnic",
+                            "--compartment-id",
+                            instance_compartment,
+                            "--vnic-id",
+                            vnic_id,
+                            "--force",
+                            "--wait-for-state",
+                            "DETACHED",
+                        ],
+                        details={"vnic_id": vnic_id, "instance_id": instance_id},
+                    )
+                )
+        primary_instances = {
+            candidate.resource_id
+            for candidate in candidates
+            if candidate.kind == "compute-instance"
+        }
+        return [
+            candidate
+            for candidate in candidates
+            if candidate.kind != "secondary-vnic"
+            or candidate.details.get("instance_id") not in primary_instances
+        ]
+
+    def _discover_network_extras(
+        self, context: CleanupContext, region: str
+    ) -> list[ExtraResourceCandidate]:
+        vcns = self._list_region(
+            region,
+            [
+                "network",
+                "vcn",
+                "list",
+                "--compartment-id",
+                context.compartment_id,
+            ],
+        )
+        owned_vcns = [
+            vcn
+            for vcn in vcns
+            if exact_owned(
+                vcn,
+                expected_names={VCN_NAME},
+                compartment_id=context.compartment_id,
+            )
+        ]
+        candidates: list[ExtraResourceCandidate] = []
+        for vcn in owned_vcns:
+            vcn_id = resource_id(vcn)
+            default_route_table_id = str(
+                resource_field(vcn, "default-route-table-id", "")
+            )
+            subnets = self._list_region(
+                region,
+                [
+                    "network",
+                    "subnet",
+                    "list",
+                    "--compartment-id",
+                    context.compartment_id,
+                    "--vcn-id",
+                    vcn_id,
+                ],
+            )
+            for subnet in subnets:
+                if is_deleted_or_deleting(subnet):
+                    continue
+                if exact_owned(
+                    subnet,
+                    expected_names={SUBNET_NAME},
+                    compartment_id=context.compartment_id,
+                ):
+                    candidates.extend(
+                        self._discover_vnic_extras(context, region, subnet)
+                    )
+                    continue
+                candidates.append(
+                    self._extra_candidate(
+                        kind="subnet",
+                        resource=subnet,
+                        region=region,
+                        container_id=vcn_id,
+                        container_name=VCN_NAME,
+                        impact=(
+                            "Deleting this subnet may be required before the "
+                            "owned VCN can be deleted."
+                        ),
+                        command=[
+                            "--region",
+                            region,
+                            "network",
+                            "subnet",
+                            "delete",
+                            "--subnet-id",
+                            resource_id(subnet),
+                            "--force",
+                            "--wait-for-state",
+                            "TERMINATED",
+                        ],
+                    )
+                )
+            route_tables = self._list_region(
+                region,
+                [
+                    "network",
+                    "route-table",
+                    "list",
+                    "--compartment-id",
+                    context.compartment_id,
+                    "--vcn-id",
+                    vcn_id,
+                ],
+            )
+            for route_table in route_tables:
+                if is_deleted_or_deleting(route_table):
+                    continue
+                identifier = resource_id(route_table)
+                if identifier == default_route_table_id or is_owned(route_table):
+                    continue
+                candidates.append(
+                    self._extra_candidate(
+                        kind="route-table",
+                        resource=route_table,
+                        region=region,
+                        container_id=vcn_id,
+                        container_name=VCN_NAME,
+                        impact=(
+                            "Deleting this route table may be required before "
+                            "the owned VCN can be deleted."
+                        ),
+                        command=[
+                            "--region",
+                            region,
+                            "network",
+                            "route-table",
+                            "delete",
+                            "--rt-id",
+                            identifier,
+                            "--force",
+                        ],
+                    )
+                )
+            gateway_specs = [
+                _GatewaySpec(
+                    "nat-gateway",
+                    "nat-gateway",
+                    "--nat-gateway-id",
+                    NAT_GATEWAY_NAME,
+                    False,
+                ),
+                _GatewaySpec(
+                    "service-gateway",
+                    "service-gateway",
+                    "--service-gateway-id",
+                    SERVICE_GATEWAY_NAME,
+                    False,
+                ),
+                _GatewaySpec(
+                    "internet-gateway",
+                    "internet-gateway",
+                    "--ig-id",
+                    None,
+                    True,
+                ),
+                _GatewaySpec(
+                    "local-peering-gateway",
+                    "local-peering-gateway",
+                    "--local-peering-gateway-id",
+                    None,
+                    True,
+                ),
+            ]
+            for spec in gateway_specs:
+                gateways = self._list_region(
+                    region,
+                    [
+                        "network",
+                        spec.cli_kind,
+                        "list",
+                        "--compartment-id",
+                        context.compartment_id,
+                        "--vcn-id",
+                        vcn_id,
+                    ],
+                )
+                for gateway in gateways:
+                    if is_deleted_or_deleting(gateway):
+                        continue
+                    if not spec.always_extra and exact_owned(
+                        gateway,
+                        expected_names={spec.expected_owned_name or ""},
+                        compartment_id=context.compartment_id,
+                    ):
+                        continue
+                    candidates.append(
+                        self._extra_candidate(
+                            kind=spec.kind,
+                            resource=gateway,
+                            region=region,
+                            container_id=vcn_id,
+                            container_name=VCN_NAME,
+                            impact=(
+                                "Deleting this gateway may be required before "
+                                "the owned VCN can be deleted."
+                            ),
+                            command=[
+                                "--region",
+                                region,
+                                "network",
+                                spec.cli_kind,
+                                "delete",
+                                spec.id_flag,
+                                resource_id(gateway),
+                                "--force",
+                                "--wait-for-state",
+                                "TERMINATED",
+                            ],
+                        )
+                    )
+        return candidates
+
+    def discover_extra_resources(
+        self, context: CleanupContext
+    ) -> list[ExtraResourceCandidate]:
+        LOGGER.info("Discovering extra resources inside owned Datadog containers")
+        candidates: dict[str, ExtraResourceCandidate] = {}
+        for region in context.regions:
+            discovered = self._discover_network_extras(context, region)
+            for candidate in discovered:
+                candidates[candidate.candidate_id] = candidate
+        return sorted(
+            candidates.values(),
+            key=lambda candidate: (
+                candidate.region,
+                candidate.container_name,
+                candidate.kind,
+                candidate.resource_id,
+            ),
+        )
+
+    def _ask_yes_no(self, prompt: str) -> bool:
+        stream = sys.stdin
+        if not stream.isatty():
+            LOGGER.warning("%s [y/n]: no interactive TTY; defaulting to n", prompt)
+            return False
+        while True:
+            print(f"{prompt} [y/n]: ", end="", file=sys.stderr, flush=True)
+            answer = stream.readline()
+            if not answer:
+                LOGGER.warning("Input ended; defaulting to n")
+                return False
+            normalized = answer.strip().lower()
+            if normalized == "y":
+                return True
+            if normalized == "n":
+                return False
+            print("Please answer y or n.", file=sys.stderr)
+
+    def prepare_extra_resource_cleanup(self, context: CleanupContext) -> None:
+        self.extra_candidates = self.discover_extra_resources(context)
+        approvals = self.manifest.data.setdefault("extra_resource_approvals", {})
+        for candidate in self.extra_candidates:
+            review = {
+                "id": f"review:{candidate.candidate_id}",
+                "description": (
+                    f"Review extra {candidate.kind} {candidate.name} "
+                    f"({candidate.resource_id}) in {candidate.region}"
+                ),
+                "status": "confirmation-required",
+                "resource_id": candidate.resource_id,
+                "resource_type": candidate.kind,
+                "region": candidate.region,
+                "container_id": candidate.container_id,
+                "container_name": candidate.container_name,
+                "impact": candidate.impact,
+            }
+            self.planned.append(review)
+            if not candidate.command:
+                review["status"] = "unsupported"
+                LOGGER.warning(
+                    "Blocked resource requires manual remediation:\n"
+                    "  type: %s\n  name: %s\n  OCID: %s\n  region: %s\n"
+                    "  Datadog container: %s (%s)\n  impact: %s\n"
+                    "  reason: no verified service-specific deletion handler",
+                    candidate.kind,
+                    candidate.name,
+                    candidate.resource_id,
+                    candidate.region,
+                    candidate.container_name,
+                    candidate.container_id,
+                    candidate.impact,
+                )
+                self.failures.append(
+                    f"Extra {candidate.kind} {candidate.resource_id} in "
+                    f"{candidate.container_name} cannot be safely deleted "
+                    "automatically"
+                )
+                continue
+            if not self.execute:
+                continue
+            LOGGER.warning(
+                "Blocked resource found:\n"
+                "  type: %s\n  name: %s\n  OCID: %s\n  region: %s\n"
+                "  Datadog container: %s (%s)\n  impact: %s",
+                candidate.kind,
+                candidate.name,
+                candidate.resource_id,
+                candidate.region,
+                candidate.container_name,
+                candidate.container_id,
+                candidate.impact,
+            )
+            approved = self._ask_yes_no(
+                f"Delete this blocked {candidate.kind} resource?"
+            )
+            if approved and candidate.requires_compute_confirmation:
+                LOGGER.warning(
+                    "COMPUTE INSTANCE WARNING: this permanently terminates "
+                    "instance %s. The boot volume will be preserved.",
+                    candidate.resource_id,
+                )
+                approved = self._ask_yes_no(
+                    f"Terminate Compute instance {candidate.resource_id}?"
+                )
+            if approved:
+                self.approved_extra_ids.add(candidate.candidate_id)
+                approvals[candidate.candidate_id] = {
+                    "approved": True,
+                    "approved_at": utc_now(),
+                    "resource_id": candidate.resource_id,
+                    "region": candidate.region,
+                    "kind": candidate.kind,
+                }
+                review["status"] = "approved"
+                self.manifest.save()
+            else:
+                review["status"] = "declined"
+                approvals[candidate.candidate_id] = {
+                    "approved": False,
+                    "reviewed_at": utc_now(),
+                    "resource_id": candidate.resource_id,
+                    "region": candidate.region,
+                    "kind": candidate.kind,
+                }
+                self.manifest.save()
+                self.failures.append(
+                    f"Extra {candidate.kind} {candidate.resource_id} was not "
+                    "approved for deletion"
+                )
+
+    def _candidate_is_approved(self, candidate: ExtraResourceCandidate) -> bool:
+        return candidate.candidate_id in self.approved_extra_ids
+
+    def _has_unapproved_extra(
+        self, *, region: str, container_id: str
+    ) -> bool:
+        return any(
+            candidate.region == region
+            and candidate.container_id == container_id
+            and not self._candidate_is_approved(candidate)
+            for candidate in self.extra_candidates
+        )
+
+    def _delete_approved_extras(
+        self, *, region: str, kinds: set[str]
+    ) -> bool:
+        priorities = {
+            "secondary-vnic": 0,
+            "unverified-secondary-vnic": 0,
+            "compute-instance": 0,
+            "function": 0,
+            "subnet": 1,
+            "route-table": 2,
+            "nat-gateway": 3,
+            "service-gateway": 3,
+            "internet-gateway": 3,
+            "local-peering-gateway": 3,
+        }
+        candidates = sorted(
+            (
+                candidate
+                for candidate in self.extra_candidates
+                if candidate.region == region
+                and candidate.kind in kinds
+                and self._candidate_is_approved(candidate)
+            ),
+            key=lambda candidate: (
+                priorities.get(candidate.kind, 100),
+                candidate.candidate_id,
+            ),
+        )
+        succeeded = True
+        for candidate in candidates:
+            assert candidate.command is not None
+            if not self.action(
+                candidate.candidate_id,
+                f"Delete approved extra {candidate.kind} {candidate.name} "
+                f"({candidate.resource_id}) in {region}",
+                command=list(candidate.command),
+                details={
+                    "approved_extra": True,
+                    "resource_id": candidate.resource_id,
+                    "region": region,
+                    "container_id": candidate.container_id,
+                },
+                retry_completed=True,
+            ):
+                succeeded = False
+        return succeeded
+
+

--- a/oci-integration-cleanup/oci_cleanup/engine.py
+++ b/oci-integration-cleanup/oci_cleanup/engine.py
@@ -25,6 +25,8 @@ class EngineMixin:
             "disable or remove the integration separately to prevent recreation"
         )
         context = self.discover()
+        self.prepare_extra_resource_cleanup(context)
+
         worker_count = min(self.args.region_workers, len(context.regions))
         LOGGER.info(
             "Cleaning %d region(s) with %d worker(s)",

--- a/oci-integration-cleanup/oci_cleanup/resources.py
+++ b/oci-integration-cleanup/oci_cleanup/resources.py
@@ -15,6 +15,18 @@ from typing import Any, Iterable, Optional
 
 from .constants import OWNER_KEY, OWNER_VALUE, TAG_NAME, TAG_NAMESPACE_NAME
 
+
+def resource_field(
+    resource: dict[str, Any], name: str, default: Any = None
+) -> Any:
+    """Read an OCI field from either hyphenated or normalized CLI output."""
+    aliases = (name, name.replace("-", "_"), name.replace("_", "-"))
+    for alias in dict.fromkeys(aliases):
+        if alias in resource and resource[alias] is not None:
+            return resource[alias]
+    return default
+
+
 def utc_now() -> str:
     return dt.datetime.now(dt.timezone.utc).isoformat()
 

--- a/oci-integration-cleanup/tests/test_integration_cleanup.py
+++ b/oci-integration-cleanup/tests/test_integration_cleanup.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 import integration_cleanup as cleanup
 import oci_cleanup
+from oci_cleanup.resources import resource_field
 
 
 TENANCY = "ocid1.tenancy.oc1..test"
@@ -186,6 +187,19 @@ class CleanupTestCase(unittest.TestCase):
             )
         )
 
+    def test_resource_field_supports_hyphenated_and_normalized_names(self):
+        self.assertEqual(
+            "hyphenated",
+            resource_field({"subnet-id": "hyphenated"}, "subnet-id"),
+        )
+        self.assertEqual(
+            "normalized",
+            resource_field({"subnet_id": "normalized"}, "subnet-id"),
+        )
+        self.assertFalse(
+            resource_field({"is_primary": False}, "is-primary", True)
+        )
+
     def test_execute_requires_confirmation_and_manifest(self):
         common = [
             "--tenancy-id",
@@ -259,6 +273,141 @@ class CleanupTestCase(unittest.TestCase):
         self.assertIn("Invalid value", str(raised.exception))
         self.assertEqual(process.stdout, raised.exception.stdout)
 
+    def test_extra_resource_dry_run_reports_without_prompting(self):
+        cleaner = self.make_cleaner()
+        cleaner.discover_extra_resources = lambda _context: [extra_candidate()]
+        cleaner._ask_yes_no = lambda _prompt: self.fail("dry-run prompted")
+
+        cleaner.prepare_extra_resource_cleanup(context())
+
+        self.assertEqual("confirmation-required", cleaner.planned[0]["status"])
+        self.assertEqual(set(), cleaner.approved_extra_ids)
+        self.assertEqual([], cleaner.failures)
+
+    def test_extra_resource_prompt_accepts_only_y_or_n(self):
+        cleaner = self.make_cleaner(execute=True)
+        cleaner.discover_extra_resources = lambda _context: [extra_candidate()]
+
+        with patch("oci_cleanup.domains.extras.sys.stdin", TtyInput("maybe\ny\n")):
+            with contextlib.redirect_stderr(io.StringIO()) as stderr:
+                cleaner.prepare_extra_resource_cleanup(context())
+
+        self.assertIn("Please answer y or n.", stderr.getvalue())
+        self.assertEqual(
+            {"extra:function:us-ashburn-1:extra"},
+            cleaner.approved_extra_ids,
+        )
+        self.assertEqual("approved", cleaner.planned[0]["status"])
+
+    def test_extra_resource_non_tty_fails_closed(self):
+        cleaner = self.make_cleaner(execute=True)
+        cleaner.discover_extra_resources = lambda _context: [extra_candidate()]
+
+        with patch("oci_cleanup.domains.extras.sys.stdin", io.StringIO("y\n")):
+            cleaner.prepare_extra_resource_cleanup(context())
+
+        self.assertEqual(set(), cleaner.approved_extra_ids)
+        self.assertEqual("declined", cleaner.planned[0]["status"])
+        self.assertTrue(any("not approved" in failure for failure in cleaner.failures))
+
+    def test_extra_resource_manifest_approval_prompts_on_every_execute_run(self):
+        first = self.make_cleaner(execute=True)
+        first.discover_extra_resources = lambda _context: [extra_candidate()]
+        with patch("oci_cleanup.domains.extras.sys.stdin", TtyInput("y\n")):
+            first.prepare_extra_resource_cleanup(context())
+
+        resumed = self.make_cleaner(execute=True)
+        resumed.discover_extra_resources = lambda _context: [extra_candidate()]
+        prompts = []
+        resumed._ask_yes_no = lambda prompt: prompts.append(prompt) or False
+        resumed.prepare_extra_resource_cleanup(context())
+
+        self.assertEqual(1, len(prompts))
+        self.assertEqual(set(), resumed.approved_extra_ids)
+        self.assertEqual("declined", resumed.planned[0]["status"])
+        self.assertFalse(
+            resumed.manifest.data["extra_resource_approvals"][
+                "extra:function:us-ashburn-1:extra"
+            ]["approved"]
+        )
+
+    def test_unsupported_extra_reports_manual_remediation_without_prompt(self):
+        cleaner = self.make_cleaner(execute=True)
+        candidate = extra_candidate(
+            candidate_id="extra:unsupported-vnic:us-ashburn-1:vnic",
+            kind="unsupported-vnic",
+            resource_id="vnic",
+            command=None,
+        )
+        cleaner.discover_extra_resources = lambda _context: [candidate]
+        cleaner._ask_yes_no = lambda _prompt: self.fail(
+            "unsupported resource prompted for unsafe deletion"
+        )
+
+        cleaner.prepare_extra_resource_cleanup(context())
+
+        self.assertEqual("unsupported", cleaner.planned[0]["status"])
+        self.assertTrue(
+            any("cannot be safely deleted" in failure for failure in cleaner.failures)
+        )
+
+    def test_primary_vnic_requires_second_compute_confirmation(self):
+        candidate = extra_candidate(
+            candidate_id="extra:compute-instance:us-ashburn-1:instance",
+            kind="compute-instance",
+            resource_id="instance",
+            command=("compute", "instance", "terminate"),
+            requires_compute_confirmation=True,
+        )
+        declined = self.make_cleaner(execute=True)
+        declined.discover_extra_resources = lambda _context: [candidate]
+        with patch("oci_cleanup.domains.extras.sys.stdin", TtyInput("y\nn\n")):
+            with contextlib.redirect_stderr(io.StringIO()):
+                declined.prepare_extra_resource_cleanup(context())
+        self.assertEqual("declined", declined.planned[0]["status"])
+
+        approved = self.make_cleaner(execute=True)
+        approved.discover_extra_resources = lambda _context: [candidate]
+        with patch("oci_cleanup.domains.extras.sys.stdin", TtyInput("y\ny\n")):
+            with contextlib.redirect_stderr(io.StringIO()):
+                approved.prepare_extra_resource_cleanup(context())
+        self.assertEqual("approved", approved.planned[0]["status"])
+
+    def test_approved_network_extras_delete_in_dependency_order(self):
+        cleaner = self.make_cleaner(execute=True)
+        candidates = [
+            extra_candidate(
+                candidate_id=f"extra:{kind}:{HOME_REGION}:{kind}",
+                kind=kind,
+                resource_id=kind,
+                command=("delete", kind),
+            )
+            for kind in [
+                "service-gateway",
+                "route-table",
+                "subnet",
+                "secondary-vnic",
+            ]
+        ]
+        cleaner.extra_candidates = candidates
+        cleaner.approved_extra_ids = {
+            candidate.candidate_id for candidate in candidates
+        }
+
+        cleaner._delete_approved_extras(
+            region=HOME_REGION,
+            kinds={candidate.kind for candidate in candidates},
+        )
+
+        self.assertEqual(
+            [
+                "delete secondary-vnic",
+                "delete subnet",
+                "delete route-table",
+                "delete service-gateway",
+            ],
+            [" ".join(command) for command in cleaner.oci.run_calls],
+        )
     def test_oci_success_with_malformed_json_raises_command_error(self):
         process = SimpleNamespace(
             returncode=0,
@@ -434,6 +583,209 @@ class CleanupTestCase(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual([True], invoked)
         self.assertEqual("completed", cleaner.planned[0]["status"])
+
+    def test_discovers_secondary_and_primary_compute_vnic_actions(self):
+        oci = FakeOci()
+        oci.add_run(
+            "query Vnic resources",
+            {
+                "data": {
+                    "items": [
+                        {"identifier": "primary-vnic"},
+                        {"identifier": "secondary-vnic"},
+                    ]
+                }
+            },
+        )
+        vnics = iter(
+            [
+                {
+                    "data": {
+                        "id": "primary-vnic",
+                        "display-name": "primary",
+                        "subnet-id": "subnet",
+                        "compartment-id": "instance-compartment",
+                        "is-primary": True,
+                    }
+                },
+                {
+                    "data": {
+                        "id": "secondary-vnic",
+                        "display-name": "secondary",
+                        "subnet-id": "subnet",
+                        "compartment-id": "instance-compartment",
+                        "is-primary": False,
+                    }
+                },
+            ]
+        )
+        oci.add_run("network vnic get", lambda: next(vnics))
+        attachments = iter(
+            [
+                [{"id": "primary-attachment", "instance-id": "instance-a"}],
+                [{"id": "secondary-attachment", "instance-id": "instance-b"}],
+            ]
+        )
+        oci.add_list("compute vnic-attachment list", lambda: next(attachments))
+        instances = iter(
+            [
+                {"data": {"id": "instance-a", "display-name": "primary-instance"}},
+                {"data": {"id": "instance-b", "display-name": "secondary-instance"}},
+            ]
+        )
+        oci.add_run("compute instance get", lambda: next(instances))
+        subnet = {
+            "id": "subnet",
+            "display-name": cleanup.SUBNET_NAME,
+            "compartment-id": COMPARTMENT,
+        }
+
+        candidates = self.make_cleaner(oci=oci)._discover_vnic_extras(
+            context(), HOME_REGION, subnet
+        )
+        by_kind = {candidate.kind: candidate for candidate in candidates}
+
+        self.assertIn("compute-instance", by_kind)
+        self.assertIn("secondary-vnic", by_kind)
+        self.assertTrue(by_kind["compute-instance"].requires_compute_confirmation)
+        self.assertIn(
+            "--preserve-boot-volume",
+            by_kind["compute-instance"].command or (),
+        )
+        compute_command = by_kind["compute-instance"].command or ()
+        wait_state_index = compute_command.index("--wait-for-state") + 1
+        self.assertEqual("SUCCEEDED", compute_command[wait_state_index])
+        self.assertIn("detach-vnic", by_kind["secondary-vnic"].command or ())
+
+    def test_unidentified_vnic_becomes_confirmable_detach_candidate(self):
+        oci = FakeOci()
+        oci.add_run(
+            "query Vnic resources",
+            {"data": {"items": [{"identifier": "unidentified-vnic"}]}},
+        )
+        oci.add_run(
+            "network vnic get",
+            {
+                "data": {
+                    "id": "unidentified-vnic",
+                    "display-name": "untagged-vnic",
+                    "subnet-id": "subnet",
+                    "compartment-id": "instance-compartment",
+                    "is-primary": False,
+                }
+            },
+        )
+        oci.add_list("compute vnic-attachment list", [])
+        subnet = {
+            "id": "subnet",
+            "display-name": cleanup.SUBNET_NAME,
+            "compartment-id": COMPARTMENT,
+        }
+
+        candidates = self.make_cleaner(oci=oci)._discover_vnic_extras(
+            context(), HOME_REGION, subnet
+        )
+
+        self.assertEqual(1, len(candidates))
+        candidate = candidates[0]
+        self.assertEqual("unverified-secondary-vnic", candidate.kind)
+        self.assertIn("detach-vnic", candidate.command or ())
+        self.assertIn("instance-compartment", candidate.command or ())
+
+    def test_discovers_primary_vnic_attachment_in_another_compartment(self):
+        oci = FakeOci()
+        oci.add_run(
+            "query Vnic resources",
+            {"data": {"items": [{"identifier": "cross-compartment-vnic"}]}},
+        )
+        oci.add_run(
+            "network vnic get",
+            {
+                "data": {
+                    "id": "cross-compartment-vnic",
+                    "display-name": "cross-compartment-instance",
+                    "subnet-id": "subnet",
+                    "compartment-id": COMPARTMENT,
+                    "is-primary": True,
+                }
+            },
+        )
+        oci.add_list(
+            "iam compartment list",
+            [
+                {
+                    "id": "instance-compartment",
+                    "lifecycle-state": "ACTIVE",
+                }
+            ],
+        )
+        attachment_responses = iter(
+            [
+                [],
+                [
+                    {
+                        "id": "attachment",
+                        "instance-id": "cross-compartment-instance",
+                        "lifecycle-state": "ATTACHED",
+                    }
+                ],
+            ]
+        )
+        oci.add_list(
+            "compute vnic-attachment list",
+            lambda: next(attachment_responses),
+        )
+        oci.add_run(
+            "compute instance get",
+            {
+                "data": {
+                    "id": "cross-compartment-instance",
+                    "display-name": "instance",
+                    "compartment-id": "instance-compartment",
+                }
+            },
+        )
+        subnet = {
+            "id": "subnet",
+            "display-name": cleanup.SUBNET_NAME,
+            "compartment-id": COMPARTMENT,
+        }
+
+        candidates = self.make_cleaner(oci=oci)._discover_vnic_extras(
+            context(), HOME_REGION, subnet
+        )
+
+        self.assertEqual(1, len(candidates))
+        candidate = candidates[0]
+        self.assertEqual("compute-instance", candidate.kind)
+        self.assertTrue(candidate.requires_compute_confirmation)
+        self.assertIn("terminate", candidate.command or ())
+
+    def test_compartment_inventory_failure_is_not_cached(self):
+        cleaner = self.make_cleaner()
+        transient_error = cleanup.CommandError(
+            ["oci", "iam", "compartment", "list"],
+            1,
+            "ServiceUnavailable",
+        )
+        with patch.object(
+            cleaner,
+            "_list_region",
+            side_effect=[
+                transient_error,
+                [{"id": "instance-compartment", "lifecycle-state": "ACTIVE"}],
+            ],
+        ) as list_region:
+            with self.assertLogs(cleanup.LOGGER, level="WARNING"):
+                first = cleaner._compute_compartment_ids(context())
+            second = cleaner._compute_compartment_ids(context())
+
+        self.assertEqual([COMPARTMENT, TENANCY], first)
+        self.assertEqual(
+            ["instance-compartment", COMPARTMENT, TENANCY],
+            second,
+        )
+        self.assertEqual(2, list_region.call_count)
 
     def test_run_cleans_regions_concurrently(self):
         cleaner = self.make_cleaner(


### PR DESCRIPTION
## Summary
- discover unexpected nested network and compute resources before regional cleanup
- require explicit per-run approval and fail closed without an interactive terminal
- add OCI field normalization and focused approval, VNIC, and compartment discovery coverage

## Test plan
- [x] `python3 -m unittest discover -s oci-integration-cleanup/tests -p 'test_*.py' -v`
- [x] `python3 oci-integration-cleanup/integration_cleanup.py --help`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)